### PR TITLE
Increase dependent cabal version to avoid the bug of cabal

### DIFF
--- a/critbit.cabal
+++ b/critbit.cabal
@@ -12,7 +12,7 @@ maintainer:     Bryan O'Sullivan <bos@serpentine.com>
 copyright:      2013 Bryan O'Sullivan
 category:       Data
 build-type:     Simple
-cabal-version:  >= 1.8
+cabal-version:  >= 1.16
 extra-source-files:
     README.markdown
 
@@ -21,6 +21,7 @@ flag developer
   default: False
 
 library
+  default-language: Haskell2010
   exposed-modules:
     Data.CritBit.Map.Lazy
   other-modules:
@@ -42,6 +43,7 @@ library
     cpp-options: -DASSERTS
 
 test-suite tests
+  default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: tests
   main-is:        Main.hs
@@ -62,6 +64,7 @@ test-suite tests
     text
 
 benchmark benchmarks
+  default-language: Haskell2010
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmarks
   main-is:        Benchmarks.hs


### PR DESCRIPTION
According to https://github.com/haskell/cabal/issues/1045, test suites
don't contribute to cabal_macros.h MIN_VERSION_pkg pragmas in the prev
ious version of cabal. This bug is fixed in cabal 1.16. However, haske
ll-platform 2012.4.0 comes with cabal 1.14
