### PR TITLE
Implement remaining Min\/Max functions.

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -508,11 +508,7 @@ findMax (CritBit root) = rightmost emptyMap (,) root
 -- > deleteMin (fromList [("a",5), ("b",3), ("c",7)]) == fromList [("b",3), ("c",7)]
 -- > deleteMin empty == empty
 deleteMin :: CritBit k v -> CritBit k v
-deleteMin (CritBit root) = CritBit $ go root
-  where
-    go i@(Internal left _ _ _) = i { ileft = go left }
-    go (Leaf _ _) = Empty
-    go _  = root
+deleteMin m = updateExtremity goLeft (const (const Nothing)) m
 {-# INLINABLE deleteMin #-}
 
 -- | /O(log n)/. Delete the maximal key. Returns an empty map if the
@@ -521,11 +517,7 @@ deleteMin (CritBit root) = CritBit $ go root
 -- > deleteMin (fromList [("a",5), ("b",3), ("c",7)]) == fromList [("a",5), ("b","3")]
 -- > deleteMin empty == empty
 deleteMax :: CritBit k v -> CritBit k v
-deleteMax (CritBit root) = CritBit $ go root
-  where
-    go i@(Internal _ right _ _) = i { iright = go right }
-    go (Leaf _ _) = Empty
-    go _ = root
+deleteMax m = updateExtremity goRight (const (const Nothing)) m
 {-# INLINABLE deleteMax #-}
 
 -- | /O(log n)/. Delete and find the minimal element.

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -138,10 +138,10 @@ module Data.CritBit.Tree
     -- , updateMax
     -- , updateMinWithKey
     -- , updateMaxWithKey
-    -- , minView
-    -- , maxView
-    -- , minViewWithKey
-    -- , maxViewWithKey
+    , minView
+    , maxView
+    , minViewWithKey
+    , maxViewWithKey
     ) where
 
 import Control.Applicative ((*>), (<|>), pure, liftA2)
@@ -550,11 +550,56 @@ deleteFindMax :: CritBit k v -> ((k, v), CritBit k v)
 deleteFindMax (CritBit root) = let (km, r) = go root in (km, CritBit r)
   where
     go i@(Internal _ right _ _) = (kmin, i { iright = right' })
-      where (kmin, right') = go right
-    go (Leaf k v) = ((k, v), Empty)
+      where (kmin, right')      = go right
+    go (Leaf k v)               = ((k, v), Empty)
     go _ = error "CritBit.deleteFindMin: can not return the maximal element \
                  \of an empty map"
 {-# INLINABLE deleteFindMax #-}
+
+-- | /O(log n)/. Retrieves the value associated with minimal key of the
+-- map, and the map stripped of that element, or 'Nothing' if passed an
+-- empty map.
+--
+-- > minView (fromList [("a",5), ("b",3)]) == Just (5, fromList [("b",3)])
+-- > minView empty == Nothing
+minView :: CritBit k v -> Maybe (v, CritBit k v)
+minView (CritBit Empty) = Nothing
+minView m = Just $ first snd $ deleteFindMin m
+{-# INLINABLE minView #-}
+
+-- | /O(log n)/. Retrieves the value associated with maximal key of the
+-- map, and the map stripped of that element, or 'Nothing' if passed an
+--
+-- > maxView (fromList [("a",5), ("b",3)]) == Just (3, fromList [("a",5)])
+-- > maxView empty == Nothing
+maxView :: CritBit k v -> Maybe (v, CritBit k v)
+maxView (CritBit Empty) = Nothing
+maxView m = Just $ first snd $ deleteFindMax m
+{-# INLINABLE maxView #-}
+
+-- | /O(log n)/. Retrieves the minimal (key,value) pair of the map, and
+-- the map stripped of that element, or 'Nothing' if passed an empty map.
+--
+-- > minViewWithKey (fromList [("a",5), ("b",3)]) == Just (("a",5), fromList [("b",3)])
+-- > minViewWithKey empty == Nothing
+minViewWithKey :: CritBit k v -> Maybe ((k, v), CritBit k v)
+minViewWithKey (CritBit Empty) = Nothing
+minViewWithKey m = Just $ deleteFindMin m
+{-# INLINABLE minViewWithKey #-}
+
+-- | /O(log n)/. Retrieves the maximal (key,value) pair of the map, and
+-- the map stripped of that element, or 'Nothing' if passed an empty map.
+--
+-- > maxViewWithKey (fromList [("a",5), ("b",3)]) == Just (("b",3), fromList [("a",5)])
+-- > maxViewWithKey empty == Nothing
+maxViewWithKey :: CritBit k v -> Maybe ((k,v), CritBit k v)
+maxViewWithKey (CritBit Empty) = Nothing
+maxViewWithKey m = Just $ deleteFindMax m
+{-# INLINABLE maxViewWithKey #-}
+
+first :: (a -> b) -> (a,c) -> (b,c)
+first f (x,y) = (f x, y)
+{-# INLINE first #-}
 
 -- | /O(log n)/. Insert a new key and value in the map.  If the key is
 -- already present in the map, the associated value is replaced with

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -240,6 +240,22 @@ main = do
           bench "critbit" $ whnf (C.deleteFindMax) b_critbit
         , bench "map" $ whnf (Map.deleteFindMax) b_map
         ]
+      , bgroup "minView" $ [
+          bench "critbit" $ whnf C.minView b_critbit
+        , bench "map" $ whnf Map.minView b_map
+        ]
+      , bgroup "maxView" $ [
+          bench "critbit" $ whnf C.maxView b_critbit
+        , bench "map" $ whnf Map.maxView b_map
+        ]
+      , bgroup "minViewWithKey" $ [
+          bench "critbit" $ whnf C.minViewWithKey b_critbit
+        , bench "map" $ whnf Map.minViewWithKey b_map
+        ]
+      , bgroup "maxViewWithKey" $ [
+          bench "critbit" $ whnf C.minViewWithKey b_critbit
+        , bench "map" $ whnf Map.minViewWithKey b_map
+        ]
     ]
     , bgroup "text" [
         bgroup "fromList" [

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -74,6 +74,11 @@ chartres = do
         putStrLn $ show prob ++ " " ++ show (fromIntegral mismatches / nxs)
   mapM_ go [0..100]
 
+updateFKey :: Num v => k -> v -> Maybe v
+updateFKey _ v = Just $ v + 1
+
+updateFVal :: Num v => v -> Maybe v
+updateFVal v = updateFKey undefined v
 
 main = do
   fileName <- getEnv "WORDS" `Exc.catch` \(_::IOError) ->
@@ -255,6 +260,22 @@ main = do
       , bgroup "maxViewWithKey" $ [
           bench "critbit" $ whnf C.minViewWithKey b_critbit
         , bench "map" $ whnf Map.minViewWithKey b_map
+        ]
+      , bgroup "updateMin" $ [
+          bench "critbit" $ whnf (C.updateMin updateFVal) b_critbit
+        , bench "map" $ whnf (Map.updateMin updateFVal) b_map
+        ]
+      , bgroup "updateMax" $ [
+          bench "critbit" $ whnf (C.updateMax updateFVal) b_critbit
+        , bench "map" $ whnf (Map.updateMax updateFVal) b_map
+        ]
+      , bgroup "updateMinWithKey" $ [
+          bench "critbit" $ whnf (C.updateMinWithKey updateFKey) b_critbit
+        , bench "map" $ whnf (Map.updateMinWithKey updateFKey) b_map
+        ]
+      , bgroup "updateMaxWithKey" $ [
+          bench "critbit" $ whnf (C.updateMaxWithKey updateFKey) b_critbit
+        , bench "map" $ whnf (Map.updateMaxWithKey updateFKey) b_map
         ]
     ]
     , bgroup "text" [

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -181,6 +181,23 @@ t_maxViewWithKey _ (KV kvs) =
   unfoldr C.maxViewWithKey (C.fromList kvs) ==
   unfoldr Map.maxViewWithKey (Map.fromList kvs)
 
+updateFun :: Integral v => k -> v -> Maybe v
+updateFun _ v
+  | v `rem` 2 == 0 = Nothing
+  | otherwise = Just (v + 1)
+
+t_updateMinWithKey :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_updateMinWithKey _ (KV kvs) = critUpdate == mapUpdate
+  where
+    critUpdate = C.toList $ C.updateMinWithKey  updateFun $ C.fromList kvs
+    mapUpdate  = Map.toList $ Map.updateMinWithKey updateFun $ Map.fromList kvs
+
+t_updateMaxWithKey :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_updateMaxWithKey _ (KV kvs) = critUpdate == mapUpdate
+  where
+    critUpdate = C.toList $ C.updateMaxWithKey  updateFun $ C.fromList kvs
+    mapUpdate  = Map.toList $ Map.updateMaxWithKey updateFun $ Map.fromList kvs
+
 t_insert_present :: (CritBitKey k, Ord k) => k -> k -> V -> V -> KV k -> Bool
 t_insert_present _ k v v' (KV kvs) = Map.toList m == C.toList c
   where
@@ -252,6 +269,8 @@ propertiesFor t = [
   , testProperty "t_maxView" $ t_maxView t
   , testProperty "t_minViewWithKey" $ t_minViewWithKey t
   , testProperty "t_maxViewWithKey" $ t_maxViewWithKey t
+  , testProperty "t_updateMinWithKey" $ t_updateMinWithKey t
+  , testProperty "t_updateMaxWithKey" $ t_updateMaxWithKey t
   , testProperty "t_insert_present" $ t_insert_present t
   , testProperty "t_insert_missing" $ t_insert_missing t
   , testProperty "t_insertWith_present" $ t_insertWith_present t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -6,6 +6,7 @@ module Properties
 import Control.Applicative ((<$>))
 import Data.ByteString (ByteString)
 import Data.CritBit.Map.Lazy (CritBitKey, CritBit)
+import Data.List (unfoldr)
 import Data.Text (Text)
 import Data.Word (Word8)
 import Test.Framework (Test, testGroup)
@@ -160,6 +161,26 @@ t_deleteFindMax _ (KV kvs) =
     deleteFindAll C.null C.deleteFindMax (C.fromList kvs) ==
     deleteFindAll Map.null Map.deleteFindMax (Map.fromList kvs)
 
+t_minView :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_minView _ (KV kvs) =
+  unfoldr C.minView (C.fromList kvs) ==
+  unfoldr Map.minView (Map.fromList kvs)
+
+t_maxView :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_maxView _ (KV kvs) =
+  unfoldr C.maxView (C.fromList kvs) ==
+  unfoldr Map.maxView (Map.fromList kvs)
+
+t_minViewWithKey :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_minViewWithKey _ (KV kvs) =
+  unfoldr C.minViewWithKey (C.fromList kvs) ==
+  unfoldr Map.minViewWithKey (Map.fromList kvs)
+  
+t_maxViewWithKey :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_maxViewWithKey _ (KV kvs) =
+  unfoldr C.maxViewWithKey (C.fromList kvs) ==
+  unfoldr Map.maxViewWithKey (Map.fromList kvs)
+
 t_insert_present :: (CritBitKey k, Ord k) => k -> k -> V -> V -> KV k -> Bool
 t_insert_present _ k v v' (KV kvs) = Map.toList m == C.toList c
   where
@@ -227,6 +248,10 @@ propertiesFor t = [
   , testProperty "t_deleteMax" $ t_deleteMax t
   , testProperty "t_deleteFindMin" $ t_deleteFindMin t
   , testProperty "t_deleteFindMax" $ t_deleteFindMax t
+  , testProperty "t_minView" $ t_minView t
+  , testProperty "t_maxView" $ t_maxView t
+  , testProperty "t_minViewWithKey" $ t_minViewWithKey t
+  , testProperty "t_maxViewWithKey" $ t_maxViewWithKey t
   , testProperty "t_insert_present" $ t_insert_present t
   , testProperty "t_insert_missing" $ t_insert_missing t
   , testProperty "t_insertWith_present" $ t_insertWith_present t


### PR DESCRIPTION
I did not patch the bug i introduced in deleteFindMin and deleteFindMax because i saw @RamsesDeNorre did that already.
The functions deleteMin and deleteMax are slightly slower when reimplemented in terms of update.
