### PR TITLE
implement updateWithKey and rewrite delete to use this

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -35,7 +35,6 @@ module Data.CritBit.Tree
 
     -- * Deletion
     , delete
-    , oldDelete
     -- , adjust
     -- , adjustWithKey
     -- , update

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -35,10 +35,11 @@ module Data.CritBit.Tree
 
     -- * Deletion
     , delete
+    , oldDelete
     -- , adjust
     -- , adjustWithKey
     -- , update
-    -- , updateWithKey
+    , updateWithKey
     -- , updateLookupWithKey
     -- , alter
 
@@ -221,6 +222,16 @@ notMember k m = lookupWith True (const False) k m
 lookup :: (CritBitKey k) => k -> CritBit k v -> Maybe v
 lookup k m = lookupWith Nothing Just k m
 {-# INLINABLE lookup #-}
+
+-- | /O(log n)/. Delete a key and its value from the map. When the key
+-- is not a member of the map, the original map is returned.
+--
+-- > delete "a" (fromList [("a",5), ("b",3)]) == singleton "b" 3
+-- > delete "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3)]
+-- > delete "a" empty                         == empty
+delete :: (CritBitKey k) => k -> CritBit k v -> CritBit k v
+delete = updateWithKey (\_k _v -> Nothing)
+{-# INLINABLE delete #-}
 
 -- | /O(log n)/. Returns the value associated with the given key, or
 -- the given default value if the key is not in the map.

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -168,7 +168,6 @@ main = do
                               [ bench "trie" $ whnf Trie.fromList b_revKVs ]
         ]
       , bgroup "delete" $ keyed C.delete Map.delete H.delete Trie.delete
-      , bgroup "oldDelete" $ keyed C.oldDelete Map.delete H.delete Trie.delete
       , bgroup "insert" $ keyed (flip C.insert 1) (flip Map.insert 1)
                                 (flip H.insert 1) (flip Trie.insert 1)
       , bgroup "insertWith" $ [

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -24,6 +24,7 @@ import qualified Data.HashMap.Lazy as H
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Trie as Trie
+import qualified Data.Trie.Convenience as TC
 import qualified Data.Vector as V
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Generic.Mutable as M
@@ -167,6 +168,7 @@ main = do
                               [ bench "trie" $ whnf Trie.fromList b_revKVs ]
         ]
       , bgroup "delete" $ keyed C.delete Map.delete H.delete Trie.delete
+      , bgroup "oldDelete" $ keyed C.oldDelete Map.delete H.delete Trie.delete
       , bgroup "insert" $ keyed (flip C.insert 1) (flip Map.insert 1)
                                 (flip H.insert 1) (flip Trie.insert 1)
       , bgroup "insertWith" $ [
@@ -191,6 +193,19 @@ main = do
           , bench "map" $ whnf (Map.insertWithKey f key 1) b_map_1
           ]
         ] 
+      , bgroup "updateWithKey" $
+        let f k v = Just (v + fromIntegral (C.byteCount k)) in [
+          bgroup "present" [
+            bench "critbit" $ whnf (C.updateWithKey f key) b_critbit
+          , bench "map" $ whnf (Map.updateWithKey f key) b_map
+          , bench "trie" $ whnf (TC.updateWithKey f key) b_trie
+          ]
+        , bgroup "missing" [
+            bench "critbit" $ whnf (C.updateWithKey f key) b_critbit_1
+          , bench "map" $ whnf (Map.updateWithKey f key) b_map_1
+          , bench "trie" $ whnf (TC.updateWithKey f key) b_trie_1
+          ]
+        ]
       , bgroup "lookup" $ keyed C.lookup Map.lookup H.lookup Trie.lookup
 #if MIN_VERSION_containers(0,5,0)
       , bgroup "lookupGT" $ [

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -70,6 +70,30 @@ t_delete_present _ (KV kvs) k v =
     c = C.insert k v $ C.fromList kvs
     m = Map.insert k v $ Map.fromList kvs
 
+t_updateWithKey_general :: (CritBitKey k) 
+                        => (k -> V -> CritBit k V -> CritBit k V) 
+                        -> k -> V -> CB k -> Bool
+t_updateWithKey_general h k0 v0 (CB m0) =
+    C.updateWithKey f k0 m1 == naiveUpdateWithKey f k0 m1
+  where
+    m1 = h k0 v0 m0
+    naiveUpdateWithKey g k m =
+      case C.lookup k m of
+        Just v  -> case g k v of
+                     Just v' -> C.insert k v' m
+                     Nothing -> C.delete k m
+        Nothing -> m
+    f k x
+      | even (fromIntegral x :: Int) =
+        Just (x + fromIntegral (C.byteCount k))
+      | otherwise = Nothing
+
+t_updateWithKey_present :: (CritBitKey k) => k -> V -> CB k -> Bool
+t_updateWithKey_present = t_updateWithKey_general C.insert
+
+t_updateWithKey_missing :: (CritBitKey k) => k -> V -> CB k -> Bool
+t_updateWithKey_missing = t_updateWithKey_general (\k _v m -> C.delete k m)
+
 t_unionL :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_unionL _ (KV kv0) (KV kv1) =
     Map.toList (Map.fromList kv0 `Map.union` Map.fromList kv1) ==
@@ -208,6 +232,8 @@ propertiesFor t = [
   , testProperty "t_lookupGT" $ t_lookupGT t
 #endif
   , testProperty "t_delete_present" $ t_delete_present t
+  , testProperty "t_updateWithKey_present" $ t_updateWithKey_present t
+  , testProperty "t_updateWithKey_missing" $ t_updateWithKey_missing t
   , testProperty "t_unionL" $ t_unionL t
   , testProperty "t_foldl" $ t_foldl t
   , testProperty "t_foldlWithKey" $ t_foldlWithKey t


### PR DESCRIPTION
I've split this into two commits: the first preserves the old `delete` function and includes benchmarks showing that it doesn't statistically affect performance, and the second removes it.

I didn't include a benchmark showing this, but for some reason CritBit performs even better on `updateWithKey` benchmarks relative to Map and Trie if the update function is _simpler_ (e.g. `f k v = Just (v + 1)` instead of `f k v = Just (v + fromIntegral (C.byteCount k))`.
