### PR TITLE
Implement the remaining Query functions.

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -22,6 +22,7 @@ module Data.CritBit.Tree
     , findWithDefault
     , lookupLT
     , lookupGT
+    , lookupLE
     , lookupGE
 
     -- * Construction
@@ -330,6 +331,19 @@ lookupLT k m = lookupOrd f k m
                      GT -> Just kv
                      _  -> Nothing
 {-# INLINABLE lookupLT #-}
+
+-- | /O(log n)/. Find largest key smaller or equal to the given one and return
+-- the corresponding (key, value) pair.
+--
+-- lookupLE ""  (fromList [("a",3), ("b",5)]) == Nothing
+-- lookupLE "b" (fromList [("a",3), ("c",5)]) == Just ("a",3)
+-- lookupLE "b" (fromList [("a",3), ("b",5)]) == Just ("b",5)
+lookupLE :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupLE k m = lookupOrd f k m
+  where f ord kv = case ord of
+                     LT -> Nothing
+                     _  -> Just kv
+{-# INLINABLE lookupLE #-}
 
 lookupOrd :: (CritBitKey k)
           => (Ordering -> (k,v) -> Maybe (k,v))

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -20,6 +20,7 @@ module Data.CritBit.Tree
     , notMember
     , lookup
     , findWithDefault
+    , lookupLT
     , lookupGT
     , lookupGE
 
@@ -317,6 +318,18 @@ lookupGE k m = lookupOrd f k m
                      GT -> Nothing
                      _  -> Just kv
 {-# INLINABLE lookupGE #-}
+
+-- | /O(log n)/. Find largest key smaller than the given one and return the
+-- corresponding (key, value) pair.
+--
+-- > lookupLT "a" (fromList [("a",3), ("b",5)]) == Nothing
+-- > lookupLT "b" (fromList [("a",3), ("c",5)]) == Just ("a",3)
+lookupLT :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupLT k m = lookupOrd f k m
+  where f ord kv = case ord of
+                     GT -> Just kv
+                     _  -> Nothing
+{-# INLINABLE lookupLT #-}
 
 lookupOrd :: (CritBitKey k)
           => (Ordering -> (k,v) -> Maybe (k,v))

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -21,7 +21,7 @@ module Data.CritBit.Tree
     , lookup
     , findWithDefault
     , lookupGT
-    -- , lookupGE
+    , lookupGE
 
     -- * Construction
     , empty
@@ -304,6 +304,19 @@ lookupGT k m = lookupOrd f k m
                      LT -> Just kv
                      _  -> Nothing
 {-# INLINABLE lookupGT #-}
+
+-- | /O(log n)/. Find smallest key greater or equal to the given one and return
+-- the corresponding (key, value) pair.
+--
+-- > lookupGE "a" (fromList [("a",3), ("b",5)]) == Just ("a",3)
+-- > lookupGE "b" (fromList [("a",3), ("c",5)]) == Just ("c",5)
+-- > lookupGE "c" (fromList [("a",3), ("b",5)]) == Nothing
+lookupGE :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupGE k m = lookupOrd f k m
+  where f ord kv = case ord of
+                     GT -> Nothing
+                     _  -> Just kv
+{-# INLINABLE lookupGE #-}
 
 lookupOrd :: (CritBitKey k)
           => (Ordering -> (k,v) -> Maybe (k,v))

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -287,6 +287,10 @@ main = do
           bench "critbit" $ whnf (C.lookupLT key) b_critbit
         , bench "map" $ whnf (Map.lookupLT key) b_map
         ]
+      , bgroup "lookupLE" $ [
+          bench "critbit" $ whnf (C.lookupLE key) b_critbit
+        , bench "map" $ whnf (Map.lookupLE key) b_map
+        ]
 #endif
       , bgroup "member" $ keyed C.member Map.member H.member Trie.member
       , bgroup "foldlWithKey'" $ let f a _ b = a + b

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -283,6 +283,10 @@ main = do
           bench "critbit" $ whnf (C.lookupGE key) b_critbit
         , bench "map" $ whnf (Map.lookupGE key) b_map
         ]
+      , bgroup "lookupLT" $ [
+          bench "critbit" $ whnf (C.lookupLT key) b_critbit
+        , bench "map" $ whnf (Map.lookupLT key) b_map
+        ]
 #endif
       , bgroup "member" $ keyed C.member Map.member H.member Trie.member
       , bgroup "foldlWithKey'" $ let f a _ b = a + b

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -279,6 +279,10 @@ main = do
           bench "critbit" $ whnf (C.lookupGT key) b_critbit
         , bench "map" $ whnf (Map.lookupGT key) b_map
         ]
+      , bgroup "lookupGE" $ [
+          bench "critbit" $ whnf (C.lookupGE key) b_critbit
+        , bench "map" $ whnf (Map.lookupGE key) b_map
+        ]
 #endif
       , bgroup "member" $ keyed C.member Map.member H.member Trie.member
       , bgroup "foldlWithKey'" $ let f a _ b = a + b

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -89,6 +89,10 @@ t_lookupGT _ k (KV kvs) =
 t_lookupGE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
 t_lookupGE _ k (KV kvs) =
     C.lookupGE k (C.fromList kvs) == Map.lookupGE k (Map.fromList kvs)
+
+t_lookupLT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
+t_lookupLT _ k (KV kvs) =
+    C.lookupLT k (C.fromList kvs) == Map.lookupLT k (Map.fromList kvs)
 #endif
 
 -- Test that the behaviour of a CritBit function is the same as that
@@ -489,6 +493,7 @@ propertiesFor t = [
 #if MIN_VERSION_containers(0,5,0)
   , testProperty "t_lookupGT" $ t_lookupGT t
   , testProperty "t_lookupGE" $ t_lookupGE t
+  , testProperty "t_lookupLT" $ t_lookupLT t
 #endif
   , testProperty "t_delete_present" $ t_delete_present t
   , testProperty "t_adjust_present" $ t_updateWithKey_present t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -85,6 +85,10 @@ t_lookup_missing _ k (CB m) = C.lookup k (C.delete k m) == Nothing
 t_lookupGT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
 t_lookupGT _ k (KV kvs) =
     C.lookupGT k (C.fromList kvs) == Map.lookupGT k (Map.fromList kvs)
+
+t_lookupGE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
+t_lookupGE _ k (KV kvs) =
+    C.lookupGE k (C.fromList kvs) == Map.lookupGE k (Map.fromList kvs)
 #endif
 
 -- Test that the behaviour of a CritBit function is the same as that
@@ -484,6 +488,7 @@ propertiesFor t = [
   , testProperty "t_lookup_missing" $ t_lookup_missing t
 #if MIN_VERSION_containers(0,5,0)
   , testProperty "t_lookupGT" $ t_lookupGT t
+  , testProperty "t_lookupGE" $ t_lookupGE t
 #endif
   , testProperty "t_delete_present" $ t_delete_present t
   , testProperty "t_adjust_present" $ t_updateWithKey_present t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -93,6 +93,10 @@ t_lookupGE _ k (KV kvs) =
 t_lookupLT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
 t_lookupLT _ k (KV kvs) =
     C.lookupLT k (C.fromList kvs) == Map.lookupLT k (Map.fromList kvs)
+
+t_lookupLE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
+t_lookupLE _ k (KV kvs) =
+    C.lookupLE k (C.fromList kvs) == Map.lookupLE k (Map.fromList kvs)
 #endif
 
 -- Test that the behaviour of a CritBit function is the same as that
@@ -494,6 +498,7 @@ propertiesFor t = [
   , testProperty "t_lookupGT" $ t_lookupGT t
   , testProperty "t_lookupGE" $ t_lookupGE t
   , testProperty "t_lookupLT" $ t_lookupLT t
+  , testProperty "t_lookupLE" $ t_lookupLE t
 #endif
   , testProperty "t_delete_present" $ t_delete_present t
   , testProperty "t_adjust_present" $ t_updateWithKey_present t


### PR DESCRIPTION
When using an Ord constraint and 'compare' instead of 'byteCompare' we gain about 40ns.
