### PR TITLE
Conditionally compile tests and benchmarks for containers >= 0.5

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -308,12 +308,14 @@ main = do
           bench "critbit" $ whnf (C.updateMax updateFVal) b_critbit
         , bench "map" $ whnf (Map.updateMax updateFVal) b_map
         ]
-      , bgroup "traverseWithKey" $ let f _ = Identity . (+3)
-                                   in function nf
-                                        (runIdentity . C.traverseWithKey f)
-                                        (runIdentity . Map.traverseWithKey f)
-                                        (runIdentity . H.traverseWithKey f)
-                                        (fmap f)
+      , bgroup "traverseWithKey" $ let f _ = Identity . (+3) in [
+          bench "critbit" $ nf (runIdentity . C.traverseWithKey f) b_critbit
+#if MIN_VERSION_containers(0,5,0)
+        , bench "map" $ nf (runIdentity . Map.traverseWithKey f) b_map
+#endif
+        , bench "hashmap" $ nf (runIdentity . H.traverseWithKey f) b_hashmap
+        , bench "trie" $ nf (fmap f) b_trie
+        ]
       , bgroup "updateMinWithKey" $ [
           bench "critbit" $ whnf (C.updateMinWithKey updateFKey) b_critbit
         , bench "map" $ whnf (Map.updateMinWithKey updateFKey) b_map

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -8,7 +8,12 @@ import Control.Arrow (second)
 import Data.ByteString (ByteString)
 import Data.CritBit.Map.Lazy (CritBitKey, CritBit)
 import Data.Foldable (foldMap)
+
+--only needed for a test requiring contairs >= 0.5
+#if MIN_VERSION_containers(0,5,0)
 import Data.Functor.Identity (Identity(..))
+#endif
+
 import Data.List (unfoldr)
 import Data.Map (Map)
 import Data.Monoid (Sum(..))
@@ -303,6 +308,7 @@ t_mapWithKey _ (KV kvs) = mappedC == mappedM
         mappedC = C.toList . C.mapWithKey fun $ (C.fromList kvs)
         mappedM = Map.toList . Map.mapWithKey fun $ (Map.fromList kvs)
 
+#if MIN_VERSION_containers(0,5,0)
 t_traverseWithKey :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_traverseWithKey _ (KV kvs) = mappedC == mappedM
   where fun _   = Identity . show . (+3)
@@ -310,6 +316,7 @@ t_traverseWithKey _ (KV kvs) = mappedC == mappedM
                   (C.fromList kvs)
         mappedM = Map.toList . runIdentity . Map.traverseWithKey fun $
                   (Map.fromList kvs)
+#endif
 
 propertiesFor :: (Arbitrary k, CritBitKey k, Ord k, Show k) => k -> [Test]
 propertiesFor t = [
@@ -359,7 +366,9 @@ propertiesFor t = [
   , testProperty "t_insertWith_missing" $ t_insertWith_missing t
   , testProperty "t_insertWithKey_present" $ t_insertWithKey_present t
   , testProperty "t_insertWithKey_missing" $ t_insertWithKey_missing t
+#if MIN_VERSION_containers(0,5,0)
   , testProperty "t_traverseWithKey" $ t_traverseWithKey t
+#endif
   , testProperty "t_foldMap" $ t_foldMap t
   ]
 


### PR DESCRIPTION
Some recently added tests and benchmarks require containers >= 0.5. We're already doing conditional compilation on this package, so I added a few more cases where a test or benchmark may be absent for containers < 0.5.
