### PR TITLE
implement mapEitherWithKey

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -116,7 +116,7 @@ module Data.CritBit.Tree
     -- , mapMaybe
     , mapMaybeWithKey
     -- , mapEither
-    -- , mapEitherWithKey
+    , mapEitherWithKey
 
     -- , split
     -- , splitLookup
@@ -547,6 +547,31 @@ mapMaybeWithKey f (CritBit root) = CritBit $ go root
                       Nothing -> Empty
                       Just v' -> Leaf k v'
     go Empty      = Empty
+{-# INLINABLE mapMaybeWithKey #-}
+
+-- | /O(n)/. Map keys\/values and separate the 'Left' and 'Right' results.
+--
+-- > let f k a = if k < "c" then Left (k ++ k) else Right (a * 2)
+-- > mapEitherWithKey f (fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+-- >     == (fromList [("a","aa"), ("b","bb")], fromList [("x",2), ("z",14)])
+-- >
+-- > mapEitherWithKey (\_ a -> Right a) (fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+-- >     == (empty, fromList [("x",1), ("b",3), ("a",5), ("z",7)])
+mapEitherWithKey :: (k -> v -> Either v1 v2)
+                 -> CritBit k v -> (CritBit k v1, CritBit k v2)
+mapEitherWithKey f (CritBit root) = (\(x,y) -> (CritBit x, CritBit y)) $ go root
+  where
+    go i@(Internal l r _ _) = (merge m1 m3, merge m2 m4)
+      where
+        ((m1,m2),(m3,m4)) = (go l, go r)
+        merge m Empty = m
+        merge Empty m = m
+        merge m m'    = i { ileft = m, iright = m' }
+    go (Leaf k v) = case f k v of
+                      Left  v' -> (Leaf k v', Empty)
+                      Right v' -> (Empty, Leaf k v')
+    go Empty      = (Empty, Empty)
+{-# INLINABLE mapEitherWithKey #-}
 
 -- | /O(log n)/. The minimal key of the map. Calls 'error' if the map
 -- is empty.

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -145,7 +145,7 @@ module Data.CritBit.Tree
     ) where
 
 import Control.Applicative (Applicative(..), (<$>), (*>), (<|>), pure, liftA2)
-import Control.Arrow (second)
+import Control.Arrow (second, (***))
 import Control.Monad (guard)
 import Data.CritBit.Core
 import Data.CritBit.Types.Internal
@@ -559,7 +559,7 @@ mapMaybeWithKey f (CritBit root) = CritBit $ go root
 -- >     == (empty, fromList [("x",1), ("b",3), ("a",5), ("z",7)])
 mapEitherWithKey :: (k -> v -> Either v1 v2)
                  -> CritBit k v -> (CritBit k v1, CritBit k v2)
-mapEitherWithKey f (CritBit root) = (\(x,y) -> (CritBit x, CritBit y)) $ go root
+mapEitherWithKey f (CritBit root) = (CritBit *** CritBit) $ go root
   where
     go i@(Internal l r _ _) = (merge m1 m3, merge m2 m4)
       where

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -284,6 +284,14 @@ main = do
           bench "critbit" $ whnf (C.mapMaybeWithKey f) b_critbit
         , bench "map" $ whnf (Map.mapMaybeWithKey f) b_map
         ]
+      , bgroup "mapEitherWithKey" $
+        let f k v | even (fromIntegral v :: Int) =
+                    Left (v + fromIntegral (C.byteCount k))
+                  | otherwise = Right (2 * v)
+        in [
+          bench "critbit" $ nf (C.mapEitherWithKey f) b_critbit
+        , bench "map" $ nf (Map.mapEitherWithKey f) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -131,6 +131,19 @@ t_mapMaybeWithKey _ (CB m) = C.mapMaybeWithKey f m ==
         Just (x + fromIntegral (C.byteCount k))
       | otherwise = Nothing
 
+t_mapEitherWithKey :: (CritBitKey k) => k -> CB k -> Bool
+t_mapEitherWithKey _ (CB m) = C.mapEitherWithKey f m ==
+    (C.map (\(Left  x) -> x) (C.filter isLeft (C.mapWithKey f m)),
+     C.map (\(Right x) -> x) (C.filter isRight (C.mapWithKey f m)))
+  where
+    f k x
+      | even (fromIntegral x :: Int) =
+        Left (x + fromIntegral (C.byteCount k))
+      | otherwise = Right (2 * x)
+    isLeft (Left _) = True
+    isLeft _        = False
+    isRight         = not . isLeft
+
 t_unionL :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_unionL _ (KV kv0) (KV kv1) =
     Map.toList (Map.fromList kv0 `Map.union` Map.fromList kv1) ==
@@ -402,6 +415,7 @@ propertiesFor t = [
   , testProperty "t_updateWithKey_present" $ t_updateWithKey_present t
   , testProperty "t_updateWithKey_missing" $ t_updateWithKey_missing t
   , testProperty "t_mapMaybeWithKey" $ t_mapMaybeWithKey t
+  , testProperty "t_mapEitherWithKey" $ t_mapEitherWithKey t
   , testProperty "t_unionL" $ t_unionL t
   , testProperty "t_unionR" $ t_unionR t
   , testProperty "t_unionWith" $ t_unionWith t


### PR DESCRIPTION
I tried to use this to implement `mapMaybeWithKey`, but the naive way (composing the mapped function with a function taking `Right`s to `Just`s ...) was twice as slow.
