### PR TITLE
split and splitLookup

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -118,8 +118,8 @@ module Data.CritBit.Tree
     -- , mapEither
     -- , mapEitherWithKey
 
-    -- , split
     -- , splitLookup
+    , split
 
     -- * Submap
     -- , isSubmapOf
@@ -547,6 +547,35 @@ mapMaybeWithKey f (CritBit root) = CritBit $ go root
                       Nothing -> Empty
                       Just v' -> Leaf k v'
     go Empty      = Empty
+
+-- | /O(log n)/. The expression (@'split' k map@) is a pair @(map1,map2)@ where
+-- the keys in @map1@ are smaller than @k@ and the keys in @map2@ larger than @k@.
+-- Any key equal to @k@ is found in neither @map1@ nor @map2@.
+--
+-- > split "a" (fromList [("b",1), ("d",2)]) == (empty, fromList [("b",1), ("d",2)])
+-- > split "b" (fromList [("b",1), ("d",2)]) == (empty, singleton "d" 2)
+-- > split "c" (fromList [("b",1), ("d",2)]) == (singleton "b" 1, singleton "d" 2)
+-- > split "d" (fromList [("b",1), ("d",2)]) == (singleton "b" 1, empty)
+-- > split "e" (fromList [("b",1), ("d",2)]) == (fromList [("b",1), ("d",2)], empty)
+split :: (CritBitKey k) => k -> CritBit k v -> (CritBit k v, CritBit k v)
+-- Note that this is nontrivially faster than an implementation
+-- in terms of 'splitLookup'.
+split k (CritBit root) = (\(ln,rn) -> (CritBit ln, CritBit rn)) $ go root
+  where
+    go i@(Internal left right _ _)
+      | direction k i == 0 = case go left of
+                               (lt,Empty) -> (lt, right)
+                               (lt,l)     -> (lt, i { ileft = l })
+      | otherwise          = case go right of
+                               (Empty,gt) -> (left, gt)
+                               (r,gt)     -> (i { iright = r }, gt)
+    go (Leaf lk lv) =
+      case byteCompare lk k of
+        LT -> ((Leaf lk lv), Empty)
+        GT -> (Empty, (Leaf lk lv))
+        EQ -> (Empty, Empty)
+    go _ = (Empty,Empty)
+{-# INLINABLE split #-}
 
 -- | /O(log n)/. The minimal key of the map. Calls 'error' if the map
 -- is empty.

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -347,8 +347,8 @@ main = do
         , bench "map" $ whnf (Map.updateMaxWithKey updateFKey) b_map
         ]
       , bgroup "foldMap" $ [
-          bench "critbit" $ let c_foldmap :: (C.CritBitKey k, Num v) 
-                                          => C.CritBit k v 
+          bench "critbit" $ let c_foldmap :: (C.CritBitKey k, Num v)
+                                          => C.CritBit k v
                                           -> Sum v
                                 c_foldmap = foldMap Sum
                             in whnf c_foldmap b_critbit
@@ -358,9 +358,9 @@ main = do
                             m_foldmap = foldMap Sum
                         in whnf m_foldmap b_map
         ]
-      , bgroup "alter" $ let altF (Just v) = 
-                                  if odd v 
-                                    then Just (v+1) 
+      , bgroup "alter" $ let altF (Just v) =
+                                  if odd v
+                                    then Just (v+1)
                                     else Nothing
                              altF Nothing  = Just 1
                           in [

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -284,6 +284,12 @@ main = do
           bench "critbit" $ whnf (C.mapMaybeWithKey f) b_critbit
         , bench "map" $ whnf (Map.mapMaybeWithKey f) b_map
         ]
+      , bgroup "split" $
+        let forceTuple (a,b) = a `seq` b `seq` (a,b)
+        in [
+          bench "critbit" $ whnf (forceTuple . C.split key) b_critbit
+        , bench "map" $ whnf (forceTuple . Map.split key) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -290,6 +290,12 @@ main = do
           bench "critbit" $ whnf (forceTuple . C.split key) b_critbit
         , bench "map" $ whnf (forceTuple . Map.split key) b_map
         ]
+      , bgroup "splitLookup" $
+        let forceTuple (a,_,b) = a `seq` b `seq` (a,b)
+        in [
+          bench "critbit" $ whnf (forceTuple . C.splitLookup key) b_critbit
+        , bench "map" $ whnf (forceTuple . Map.splitLookup key) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -444,7 +444,7 @@ propertiesFor t = [
   , testProperty "t_insertWithKey_missing" $ t_insertWithKey_missing t
   , testProperty "t_traverseWithKey" $ t_traverseWithKey t
   , testProperty "t_foldMap" $ t_foldMap t
-  , testProperty "t_alter" $ t_alter t 
+  , testProperty "t_alter" $ t_alter t
   , testProperty "t_alter_delete" $ t_alter_delete t
   ]
 

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -256,6 +256,18 @@ t_split_missing :: (CritBitKey k, Ord k) => k -> V -> KV k -> Bool
 t_split_missing k v kvs =
   t_split_general k (cbMissing k v kvs)
 
+t_splitLookup_present :: (CritBitKey k, Ord k) => k -> V -> KV k -> Bool
+t_splitLookup_present k0 v0 kvs = (lt, Just v0, gt) == C.splitLookup k0 cb
+  where cb = cbPresent k0 v0 kvs
+        lt = C.filterWithKey (\k _ -> k < k0) cb
+        gt = C.filterWithKey (\k _ -> k > k0) cb
+
+t_splitLookup_missing :: (CritBitKey k, Ord k) => k -> V -> KV k -> Bool
+t_splitLookup_missing k0 v0 kvs = (lt, Nothing, gt) == C.splitLookup k0 cb
+  where cb = cbMissing k0 v0 kvs
+        lt = C.filterWithKey (\k _ -> k < k0) cb
+        gt = C.filterWithKey (\k _ -> k > k0) cb
+
 t_findMin :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_findMin _ (KV kvs)
   | null kvs  = True
@@ -446,6 +458,8 @@ propertiesFor t = [
   , testProperty "t_filter" $ t_filter t
   , testProperty "t_split_present" $ t_split_present t
   , testProperty "t_split_missing" $ t_split_missing t
+  , testProperty "t_splitLookup_present" $ t_split_present t
+  , testProperty "t_splitLookup_missing" $ t_split_missing t
   , testProperty "t_findMin" $ t_findMin t
   , testProperty "t_findMax" $ t_findMax t
   , testProperty "t_deleteMin" $ t_deleteMin t


### PR DESCRIPTION
I started this work not having noticed archblob's pull request, but for now this implementation is ~40% faster. I did not implement `split` as a wrapper around `splitLookup` because the separate implementation is nontrivially faster, but I worry that the code bloat and maintenance difficulty could be a greater concern..
