### PR TITLE
Implemented intersection, intersectionWith and intersectionWithKey

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -953,7 +953,7 @@ insertWith f = insertWithKey (\_ v v' -> f v v')
 -- >  let f key x = show key ++ ":" ++ show x
 -- >  mapWithKey f (fromList [("a",5), ("b",3)]) == fromList [("a","a:5"), ("b","b:3")]
 mapWithKey :: (CritBitKey k) => (k -> v -> w) -> CritBit k v -> CritBit k w
-mapWithKey f (CritBit root) = CritBit $ go root
+mapWithKey f (CritBit root) = CritBit (go root)
   where
     go i@(Internal l r _ _) = i { ileft = go l, iright = go r }
     go (Leaf k v)           = Leaf k (f k v)

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -528,7 +528,7 @@ unionsWith f cs = List.foldl' (unionWith f) empty cs
 --
 -- > let l = fromList [("a", 5), ("b", 3)]
 -- > let r = fromList [("A", 2), ("b", 7)]
--- > intersection l r == singleton "b" 3
+-- > intersection l r == fromList [("b", 3)]
 intersection :: (CritBitKey k) => CritBit k v -> CritBit k v -> CritBit k v
 intersection a b = intersectionWithKey (\_ x _ -> x) a b
 {-# INLINEABLE intersection #-}
@@ -543,7 +543,7 @@ intersectionWith :: (CritBitKey k) => (v -> v -> v)
 intersectionWith f a b = intersectionWithKey (const f) a b
 {-# INLINEABLE intersectionWith #-}
 
--- | /O(n+m)/. Union with a combining function.
+-- | /O(n+m)/. Intersection with a combining function.
 --
 -- > let f key new_value old_value = length key + new_value + old_value
 -- > let l = fromList [("a", 5), ("b", 3)]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -324,6 +324,20 @@ main = do
           bench "critbit" $ whnf (C.unionsWith (+)) [b_critbit_13, b_critbit_23]
         , bench "map" $ whnf (Map.unionsWith (+)) [b_map_13, b_map_23]
         ]
+      , bgroup "intersection" [
+          bench "critbit" $ whnf (C.intersection b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.intersection b_map_13) b_map_23
+        , bench "hashmap" $ whnf (H.intersection b_hashmap_13) b_hashmap_23
+        ]
+      , bgroup "intersectionWith" [
+          bench "critbit" $ whnf (C.intersectionWith (+) b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.intersectionWith (+) b_map_13) b_map_23
+        , bench "hashmap" $ whnf (H.intersectionWith (+) b_hashmap_13) b_hashmap_23
+        ]
+      , bgroup "intersectionWithKey" $ let f _ a b = a + b in [
+          bench "critbit" $ whnf (C.intersectionWithKey f b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.intersectionWithKey f b_map_13) b_map_23
+        ]
       , bgroup "toAscList" $ function nf C.toAscList Map.toAscList id id
       , bgroup "toDescList" $ function nf C.toDescList Map.toDescList id id
       , bgroup "filter" $ let p  = (< 128)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -256,6 +256,22 @@ t_unionsWith _ (Small kvs0) =
   where
     kvs = map fromKV kvs0
 
+t_intersection :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_intersection k (KV kvs) = (C.intersection (C.fromList kvs) === 
+    Map.intersection (Map.fromList kvs)) k
+
+t_intersectionWith :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_intersectionWith k (KV kvs) = 
+    (C.intersectionWith (-) (C.fromList kvs) ===
+        Map.intersectionWith (-) (Map.fromList kvs)) k
+
+t_intersectionWithKey :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_intersectionWithKey k (KV kvs) = 
+    (C.intersectionWithKey f (C.fromList kvs) ===
+        Map.intersectionWithKey f (Map.fromList kvs)) k
+  where
+    f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
+
 t_foldl :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_foldl = isoWith id id (C.foldl (-) 0) (Map.foldl (-) 0)
 
@@ -504,6 +520,9 @@ propertiesFor t = [
   , testProperty "t_unionWithKey" $ t_unionWithKey t
   , testProperty "t_unions" $ t_unions t
   , testProperty "t_unionsWith" $ t_unionsWith t
+  , testProperty "t_intersection" $ t_intersection t
+  , testProperty "t_intersectionWith" $ t_intersectionWith t
+  , testProperty "t_intersectionWithKey" $ t_intersectionWithKey t
   , testProperty "t_foldl" $ t_foldl t
   , testProperty "t_foldlWithKey" $ t_foldlWithKey t
   , testProperty "t_foldl'" $ t_foldl' t


### PR DESCRIPTION
Leaf and switch functions really need that many arguments:
- minimum key for each node are handled explicitly to ensure _O(n+m)_ performance
- current implementation is twice as fast as pairs-based implementation (commit 61257ca92b52e1f2c0d9759c201f2f637ec8cd27) 

Difference and faster union will follow
