### PR TITLE
Implemented intersection and difference methods

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -560,65 +560,7 @@ differenceWith f a b = differenceWithKey (const f) a b
 -- > differenceWithKey f l r == fromList [("b", 11), ("c", 8)]
 differenceWithKey :: (CritBitKey k) => (k -> v -> v -> Maybe v)
                     -> CritBit k v -> CritBit k v -> CritBit k v
-differenceWithKey f (CritBit lt) (CritBit rt) = CritBit $ top lt rt
-  where
-    -- Assumes that empty nodes exist only on the top level
-    top Empty _ = Empty
-    top a Empty = a
-    top a b = go a (minKey a) b (minKey b)
-
-    -- Each node is followed by the minimum key in that node.
-    -- This trick assures that overall time spend by minKey in O(n+m)
-    go a@(Leaf ak av) _ (Leaf bk bv) _
-        | ak == bk = case f ak av bv of
-                       Just v  -> Leaf ak v
-                       Nothing -> Empty
-        | otherwise = a
-    go a@(Leaf _ _) ak b@(Internal _ _ _ _) bk = 
-      leaf a b bk (splitB a ak b bk) a
-    go a@(Internal _ _ _ _) ak b@(Leaf _ _) bk =
-      leaf b a ak (splitA a ak b bk) a
-    go a@(Internal al ar abyte abits) ak b@(Internal bl br bbyte bbits) bk =
-      case compare (abyte, abits) (bbyte, bbits) of
-        LT -> splitA a ak b bk
-        GT -> splitB a ak b bk
-        EQ -> link a (go al ak bl bk) (go ar (minKey ar) br (minKey br))
-    -- Assumes that empty nodes exist only on the top level
-    go _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey: Empty")
-    
-    leaf (Leaf lk _) (Internal _ _ sbyte sbits) sk before after =
-        if dbyte > sbyte || dbyte == sbyte && dbits >= sbits
-        then before
-        else after
-      where
-        (dbyte, dbits, _) = followPrefixes lk sk
-    leaf _ _ _ _ _ = 
-        error("Data.CritBit.Tree.differenceWithKey.leaf: unpossible")
-    {-# INLINE leaf #-}
-
-    switch k n a0 b0 a1 b1 = if direction k n == 0 
-                             then link n a0 b0         
-                             else link n a1 b1
-    {-# INLINE switch #-}
-
-    splitA a@(Internal al ar _ _) ak b bk =
-        switch bk a (go al ak b bk) ar al (go ar (minKey ar) b bk)
-    splitA _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey.splitA: unpossible")
-
-    splitB a ak b@(Internal bl br _ _) bk =
-        switch ak b (go a ak bl bk) Empty Empty (go a ak br (minKey br))
-    splitB _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey.splitB: unpossible")
-
-    link _ Empty b = b
-    link _ a Empty = a
-    link (Internal _ _ byte bits) a b = Internal a b byte bits
-    link _ _ _ = error("Data.CritBit.Tree.differenceWithKey.link: unpossible")
-    {-# INLINE link #-}
-
-    -- minKey processes each node at most once,
-    -- including recursive calls in the implementation of leftmost
-    minKey n = leftmost (error "Empty node in tree") (\k _ -> k) n
-    {-# INLINE minKey #-}
+differenceWithKey = binarySetOpWithKey id
 {-# INLINEABLE differenceWithKey #-}
 
 -- | /O(n+m)/. Intersection of two maps. 
@@ -649,55 +591,77 @@ intersectionWith f a b = intersectionWithKey (const f) a b
 -- > intersectionWithKey f l r == fromList [("b", 11)]
 intersectionWithKey :: (CritBitKey k) => (k -> v -> v -> v)
                     -> CritBit k v -> CritBit k v -> CritBit k v
-intersectionWithKey f (CritBit lt) (CritBit rt) = CritBit $ top lt rt
+intersectionWithKey f = binarySetOpWithKey (const Empty) f'
+  where
+    f' k v1 v2 = Just (f k v1 v2)
+
+-- | Performs binary set operation on two maps
+binarySetOpWithKey :: (CritBitKey k)
+    => (Node k v -> Node k v) -- ^ Process unmatched node in first map
+    -> (k -> v -> v -> Maybe v) -- ^ Process matching values
+    -> CritBit k v -- ^ First map
+    -> CritBit k v -- ^ Second map
+    -> CritBit k v
+binarySetOpWithKey left both (CritBit lt) (CritBit rt) = CritBit $ top lt rt
   where
     -- Assumes that empty nodes exist only on the top level
     top Empty _ = Empty
-    top _ Empty = Empty
+    top a Empty = left a
     top a b = go a (minKey a) b (minKey b)
 
     -- Each node is followed by the minimum key in that node.
     -- This trick assures that overall time spend by minKey in O(n+m)
-    go (Leaf ak av) _ (Leaf bk bv) _
-        | ak == bk  = Leaf ak $ f ak av bv
-        | otherwise = Empty
-    go a@(Leaf _ _) ak b@(Internal bl br _ _) bk = 
-      leaf a b bk a ak bl bk a ak br (minKey br)
-    go a@(Internal al ar _ _) ak b@(Leaf    _ _) bk =
-      leaf b a ak al ak b ak ar (minKey ar) b bk
+    go a@(Leaf ak av) _ (Leaf bk bv) _
+        | ak == bk = case both ak av bv of
+                       Just v  -> Leaf ak v
+                       Nothing -> Empty
+        | otherwise = left a
+    go a@(Leaf _ _) ak b@(Internal _ _ _ _) bk = 
+      leaf a b bk (splitB a ak b bk) (left a)
+    go a@(Internal _ _ _ _) ak b@(Leaf _ _) bk =
+      leaf b a ak (splitA a ak b bk) (left a)
     go a@(Internal al ar abyte abits) ak b@(Internal bl br bbyte bbits) bk =
       case compare (abyte, abits) (bbyte, bbits) of
-        LT -> switch bk a al ak b ak ar (minKey ar) b bk
-        GT -> switch ak b a ak bl bk a ak br (minKey br)
-        EQ -> link (go al ak bl bk) (go ar (minKey ar) br (minKey br))
-      where
-        link Empty b' = b'
-        link a' Empty = a'
-        link a' b' = Internal a' b' abyte abits
+        LT -> splitA a ak b bk
+        GT -> splitB a ak b bk
+        EQ -> link a (go al ak bl bk) (go ar (minKey ar) br (minKey br))
     -- Assumes that empty nodes exist only on the top level
     go _ _ _ _ = error("Data.CritBit.Tree.intersectionWithKey: Empty")
 
-    leaf (Leaf lk _) s@(Internal _ _ sbyte sbits) 
-            sk a0 a0k b0 b0k a1 a1k b1 b1k =
+    leaf (Leaf lk _) (Internal _ _ sbyte sbits) sk before after =
         if dbyte > sbyte || dbyte == sbyte && dbits >= sbits
-        then switch lk s a0 a0k b0 b0k a1 a1k b1 b1k
-        else Empty
+        then before
+        else after
       where
         (dbyte, dbits, _) = followPrefixes lk sk
-    leaf _ _ _ _ _ _ _ _ _ _ _ = 
-        error("Data.CritBit.Tree.intersectionWithKey.leaf: unpossible")
+    leaf _ _ _ _ _ = 
+        error("Data.CritBit.Tree.differenceWithKey.leaf: unpossible")
     {-# INLINE leaf #-}
 
-    switch k n a0 a0k b0 b0k a1 a1k b1 b1k = if direction k n == 0 
-                                             then go a0 a0k b0 b0k
-                                             else go a1 a1k b1 b1k
+    switch k n a0 b0 a1 b1 = if direction k n == 0 
+                             then link n a0 b0         
+                             else link n a1 b1
     {-# INLINE switch #-}
 
-    -- minKey processes each node at most once,
-    -- including recursive calls in the implementation of leftmost
-    minKey n = leftmost (error "Empty node in tree") (\k _ -> k) n
+    splitA a@(Internal al ar _ _) ak b bk =
+        switch bk a (go al ak b bk) (left ar) (left al) (go ar (minKey ar) b bk)
+    splitA _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey.splitA: unpossible")
+    {-# INLINE splitA #-}
+
+    splitB a ak b@(Internal bl br _ _) bk =
+        switch ak b (go a ak bl bk) Empty Empty (go a ak br (minKey br))
+    splitB _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey.splitB: unpossible")
+    {-# INLINE splitB #-}
+
+    minKey n = leftmost (error "Data.CritBit.Tree.minKey: Empty") (\k _ -> k) n
     {-# INLINE minKey #-}
-{-# INLINEABLE intersectionWithKey #-}
+
+    link _ Empty b = b
+    link _ a Empty = a
+    link (Internal _ _ byte bits) a b = Internal a b byte bits
+    link _ _ _ = error("Data.CritBit.Tree.differenceWithKey.link: unpossible")
+    {-# INLINE link #-}
+{-# INLINEABLE binarySetOpWithKey #-}
 
 -- | /O(n)/. Apply a function to all values.
 --

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -58,9 +58,9 @@ module Data.CritBit.Tree
     , differenceWithKey
 
     -- ** Intersection
-    -- , intersection
-    -- , intersectionWith
-    -- , intersectionWithKey
+    , intersection
+    , intersectionWith
+    , intersectionWithKey
 
     -- * Traversal
     -- ** Map
@@ -620,6 +620,84 @@ differenceWithKey f (CritBit lt) (CritBit rt) = CritBit $ top lt rt
     minKey n = leftmost (error "Empty node in tree") (\k _ -> k) n
     {-# INLINE minKey #-}
 {-# INLINEABLE differenceWithKey #-}
+
+-- | /O(n+m)/. Intersection of two maps. 
+-- | Return data in the first map for the keys existing in both maps.
+--
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > intersection l r == fromList [("b", 3)]
+intersection :: (CritBitKey k) => CritBit k v -> CritBit k v -> CritBit k v
+intersection a b = intersectionWithKey (\_ x _ -> x) a b
+{-# INLINEABLE intersection #-}
+
+-- | /O(n+m)/. Intersection with a combining function.
+--
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > intersectionWith (+) l r == fromList [("b", 10)]
+intersectionWith :: (CritBitKey k) => (v -> v -> v)
+                 -> CritBit k v -> CritBit k v -> CritBit k v
+intersectionWith f a b = intersectionWithKey (const f) a b
+{-# INLINEABLE intersectionWith #-}
+
+-- | /O(n+m)/. Intersection with a combining function.
+--
+-- > let f key new_value old_value = length key + new_value + old_value
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > intersectionWithKey f l r == fromList [("b", 11)]
+intersectionWithKey :: (CritBitKey k) => (k -> v -> v -> v)
+                    -> CritBit k v -> CritBit k v -> CritBit k v
+intersectionWithKey f (CritBit lt) (CritBit rt) = CritBit $ top lt rt
+  where
+    -- Assumes that empty nodes exist only on the top level
+    top Empty _ = Empty
+    top _ Empty = Empty
+    top a b = go a (minKey a) b (minKey b)
+
+    -- Each node is followed by the minimum key in that node.
+    -- This trick assures that overall time spend by minKey in O(n+m)
+    go (Leaf ak av) _ (Leaf bk bv) _
+        | ak == bk  = Leaf ak $ f ak av bv
+        | otherwise = Empty
+    go a@(Leaf _ _) ak b@(Internal bl br _ _) bk = 
+      leaf a b bk a ak bl bk a ak br (minKey br)
+    go a@(Internal al ar _ _) ak b@(Leaf    _ _) bk =
+      leaf b a ak al ak b ak ar (minKey ar) b bk
+    go a@(Internal al ar abyte abits) ak b@(Internal bl br bbyte bbits) bk =
+      case compare (abyte, abits) (bbyte, bbits) of
+        LT -> switch bk a al ak b ak ar (minKey ar) b bk
+        GT -> switch ak b a ak bl bk a ak br (minKey br)
+        EQ -> link (go al ak bl bk) (go ar (minKey ar) br (minKey br))
+      where
+        link Empty b' = b'
+        link a' Empty = a'
+        link a' b' = Internal a' b' abyte abits
+    -- Assumes that empty nodes exist only on the top level
+    go _ _ _ _ = error("Data.CritBit.Tree.intersectionWithKey: Empty")
+
+    leaf (Leaf lk _) s@(Internal _ _ sbyte sbits) 
+            sk a0 a0k b0 b0k a1 a1k b1 b1k =
+        if dbyte > sbyte || dbyte == sbyte && dbits >= sbits
+        then switch lk s a0 a0k b0 b0k a1 a1k b1 b1k
+        else Empty
+      where
+        (dbyte, dbits, _) = followPrefixes lk sk
+    leaf _ _ _ _ _ _ _ _ _ _ _ = 
+        error("Data.CritBit.Tree.intersectionWithKey.leaf: unpossible")
+    {-# INLINE leaf #-}
+
+    switch k n a0 a0k b0 b0k a1 a1k b1 b1k = if direction k n == 0 
+                                             then go a0 a0k b0 b0k
+                                             else go a1 a1k b1 b1k
+    {-# INLINE switch #-}
+
+    -- minKey processes each node at most once,
+    -- including recursive calls in the implementation of leftmost
+    minKey n = leftmost (error "Empty node in tree") (\k _ -> k) n
+    {-# INLINE minKey #-}
+{-# INLINEABLE intersectionWithKey #-}
 
 -- | /O(n)/. Apply a function to all values.
 --

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -626,7 +626,7 @@ binarySetOpWithKey left both (CritBit lt) (CritBit rt) = CritBit $ top lt rt
         GT -> splitB a ak b bk
         EQ -> link a (go al ak bl bk) (go ar (minKey ar) br (minKey br))
     -- Assumes that empty nodes exist only on the top level
-    go _ _ _ _ = error("Data.CritBit.Tree.intersectionWithKey: Empty")
+    go _ _ _ _ = error("Data.CritBit.Tree.binarySetOpWithKey.go: Empty")
 
     leaf (Leaf lk _) (Internal _ _ sbyte sbits) sk before after =
         if dbyte > sbyte || dbyte == sbyte && dbits >= sbits
@@ -635,7 +635,7 @@ binarySetOpWithKey left both (CritBit lt) (CritBit rt) = CritBit $ top lt rt
       where
         (dbyte, dbits, _) = followPrefixes lk sk
     leaf _ _ _ _ _ = 
-        error("Data.CritBit.Tree.differenceWithKey.leaf: unpossible")
+        error("Data.CritBit.Tree.binarySetOpWithKey.leaf: unpossible")
     {-# INLINE leaf #-}
 
     switch k n a0 b0 a1 b1 = if direction k n == 0 
@@ -645,15 +645,19 @@ binarySetOpWithKey left both (CritBit lt) (CritBit rt) = CritBit $ top lt rt
 
     splitA a@(Internal al ar _ _) ak b bk =
         switch bk a (go al ak b bk) (left ar) (left al) (go ar (minKey ar) b bk)
-    splitA _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey.splitA: unpossible")
+    splitA _ _ _ _ = 
+        error("Data.CritBit.Tree.binarySetOpWithKey.splitA: unpossible")
     {-# INLINE splitA #-}
 
     splitB a ak b@(Internal bl br _ _) bk =
         switch ak b (go a ak bl bk) Empty Empty (go a ak br (minKey br))
-    splitB _ _ _ _ = error("Data.CritBit.Tree.differenceWithKey.splitB: unpossible")
+    splitB _ _ _ _ = 
+        error("Data.CritBit.Tree.binarySetOpWithKey.splitB: unpossible")
     {-# INLINE splitB #-}
 
-    minKey n = leftmost (error "Data.CritBit.Tree.minKey: Empty") (\k _ -> k) n
+    minKey n = leftmost
+        (error "Data.CritBit.Tree.binarySetOpWithKey.minKey: Empty") 
+        (\k _ -> k) n
     {-# INLINE minKey #-}
 
     link _ Empty b = b

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -324,6 +324,19 @@ main = do
           bench "critbit" $ whnf (C.unionsWith (+)) [b_critbit_13, b_critbit_23]
         , bench "map" $ whnf (Map.unionsWith (+)) [b_map_13, b_map_23]
         ]
+      , bgroup "difference" [
+          bench "critbit" $ whnf (C.difference b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.difference b_map_13) b_map_23
+        , bench "hashmap" $ whnf (H.difference b_hashmap_13) b_hashmap_23
+        ]
+      , bgroup "differenceWith" $ let f a b = Just (a + b) in [
+          bench "critbit" $ whnf (C.differenceWith f b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.differenceWith f b_map_13) b_map_23
+        ]
+      , bgroup "differenceWithKey" $ let f _ a b = Just(a + b) in [
+          bench "critbit" $ whnf (C.differenceWithKey f b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.differenceWithKey f b_map_13) b_map_23
+        ]
       , bgroup "toAscList" $ function nf C.toAscList Map.toAscList id id
       , bgroup "toDescList" $ function nf C.toDescList Map.toDescList id id
       , bgroup "filter" $ let p  = (< 128)

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -337,6 +337,20 @@ main = do
           bench "critbit" $ whnf (C.differenceWithKey f b_critbit_13) b_critbit_23
         , bench "map" $ whnf (Map.differenceWithKey f b_map_13) b_map_23
         ]
+      , bgroup "intersection" [
+          bench "critbit" $ whnf (C.intersection b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.intersection b_map_13) b_map_23
+        , bench "hashmap" $ whnf (H.intersection b_hashmap_13) b_hashmap_23
+        ]
+      , bgroup "intersectionWith" [
+          bench "critbit" $ whnf (C.intersectionWith (+) b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.intersectionWith (+) b_map_13) b_map_23
+        , bench "hashmap" $ whnf (H.intersectionWith (+) b_hashmap_13) b_hashmap_23
+        ]
+      , bgroup "intersectionWithKey" $ let f _ a b = a + b in [
+          bench "critbit" $ whnf (C.intersectionWithKey f b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.intersectionWithKey f b_map_13) b_map_23
+        ]
       , bgroup "toAscList" $ function nf C.toAscList Map.toAscList id id
       , bgroup "toDescList" $ function nf C.toDescList Map.toDescList id id
       , bgroup "filter" $ let p  = (< 128)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -278,6 +278,22 @@ t_differenceWithKey k (KV kvs) =
                   then Nothing
                   else Just (fromIntegral (C.byteCount key) + v1 - v2)
 
+t_intersection :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_intersection k (KV kvs) = (C.intersection (C.fromList kvs) === 
+    Map.intersection (Map.fromList kvs)) k
+
+t_intersectionWith :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_intersectionWith k (KV kvs) = 
+    (C.intersectionWith (-) (C.fromList kvs) ===
+        Map.intersectionWith (-) (Map.fromList kvs)) k
+
+t_intersectionWithKey :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_intersectionWithKey k (KV kvs) = 
+    (C.intersectionWithKey f (C.fromList kvs) ===
+        Map.intersectionWithKey f (Map.fromList kvs)) k
+  where
+    f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
+
 t_foldl :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_foldl = isoWith id id (C.foldl (-) 0) (Map.foldl (-) 0)
 
@@ -529,6 +545,9 @@ propertiesFor t = [
   , testProperty "t_difference" $ t_difference t
   , testProperty "t_differenceWith" $ t_differenceWith t
   , testProperty "t_differenceWithKey" $ t_differenceWithKey t
+  , testProperty "t_intersection" $ t_intersection t
+  , testProperty "t_intersectionWith" $ t_intersectionWith t
+  , testProperty "t_intersectionWithKey" $ t_intersectionWithKey t
   , testProperty "t_foldl" $ t_foldl t
   , testProperty "t_foldlWithKey" $ t_foldlWithKey t
   , testProperty "t_foldl'" $ t_foldl' t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -256,6 +256,28 @@ t_unionsWith _ (Small kvs0) =
   where
     kvs = map fromKV kvs0
 
+t_difference :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_difference k (KV kvs) = (C.difference (C.fromList kvs) === 
+    Map.difference (Map.fromList kvs)) k
+
+t_differenceWith :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_differenceWith k (KV kvs) = 
+    (C.differenceWith f (C.fromList kvs) ===
+        Map.differenceWith f (Map.fromList kvs)) k
+  where
+    f v1 v2 = if v1 `mod` 4 == 0
+              then Nothing
+              else Just (v1 - v2)
+
+t_differenceWithKey :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_differenceWithKey k (KV kvs) = 
+    (C.differenceWithKey f (C.fromList kvs) ===
+        Map.differenceWithKey f (Map.fromList kvs)) k
+  where
+    f key v1 v2 = if C.byteCount key == 2 
+                  then Nothing
+                  else Just (fromIntegral (C.byteCount key) + v1 - v2)
+
 t_foldl :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_foldl = isoWith id id (C.foldl (-) 0) (Map.foldl (-) 0)
 
@@ -504,6 +526,9 @@ propertiesFor t = [
   , testProperty "t_unionWithKey" $ t_unionWithKey t
   , testProperty "t_unions" $ t_unions t
   , testProperty "t_unionsWith" $ t_unionsWith t
+  , testProperty "t_difference" $ t_difference t
+  , testProperty "t_differenceWith" $ t_differenceWith t
+  , testProperty "t_differenceWithKey" $ t_differenceWithKey t
   , testProperty "t_foldl" $ t_foldl t
   , testProperty "t_foldlWithKey" $ t_foldlWithKey t
   , testProperty "t_foldl'" $ t_foldl' t


### PR DESCRIPTION
Minimum key for each node are handled explicitly to ensure _O(n+m)_ performance.

This is a replacement for [Pull request #52](https://github.com/bos/critbit/pull/52).
