### PR TITLE
Submap functions

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -122,9 +122,9 @@ module Data.CritBit.Tree
     , splitLookup
 
     -- * Submap
-    -- , isProperSubmapOf
     , isSubmapOf
     , isSubmapOfBy
+    , isProperSubmapOf
     , isProperSubmapOfBy
 
     -- -- * Min\/Max
@@ -718,6 +718,13 @@ isSubmapOfBy f (CritBit root1) (CritBit root2) = go root1 root2
     go Empty _ = True
     go _ _ = False
 {-# INLINABLE isSubmapOfBy #-}
+
+-- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
+-- Is this a proper submap? (ie. a submap but not equal).
+-- Defined as (@'isProperSubmapOf' = 'isProperSubmapOfBy' (==)@).
+isProperSubmapOf :: (CritBitKey k, Eq v) => CritBit k v -> CritBit k v -> Bool
+isProperSubmapOf = isProperSubmapOfBy (==)
+{-# INLINABLE isProperSubmapOf #-}
 
 data ProperBool = NotTrue
                 | TrueImp

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -123,9 +123,9 @@ module Data.CritBit.Tree
 
     -- * Submap
     -- , isSubmapOf
-    -- , isSubmapOfBy
     -- , isProperSubmapOf
     -- , isProperSubmapOfBy
+    , isSubmapOfBy
 
     -- -- * Min\/Max
     , findMin
@@ -678,6 +678,39 @@ splitLookup k (CritBit root) =
         EQ -> (Empty, Just lv, Empty)
     go _ = (Empty, Nothing, Empty)
 {-# INLINABLE splitLookup #-}
+
+{- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
+ The expression (@'isSubmapOfBy' f t1 t2@) returns 'True' if
+ all keys in @t1@ are in tree @t2@, and when @f@ returns 'True' when
+ applied to their respective values. For example, the following
+ expressions are all 'True':
+
+ > isSubmapOfBy (==) (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+ > isSubmapOfBy (<=) (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+ > isSubmapOfBy (==) (fromList [("a",1),("b",2)]) (fromList [("a",1),("b",2)])
+
+ But the following are all 'False':
+
+ > isSubmapOfBy (==) (fromList [("a",2)]) (fromList [("a",1),("b",2)])
+ > isSubmapOfBy (<)  (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+ > isSubmapOfBy (==) (fromList [("a",1),("b",2)]) (fromList [("a",1)])
+-}
+isSubmapOfBy :: (CritBitKey k) => (a -> b -> Bool) -> CritBit k a -> CritBit k b
+             -> Bool
+isSubmapOfBy f (CritBit root1) (CritBit root2) = go root1 root2
+  where
+    go (Internal l1 r1 _ _) i2 =
+      let ((key,v1), CritBit r1') = deleteFindMin $ CritBit r1
+          (CritBit lt,found,CritBit gt) = splitLookup key $ CritBit i2
+      in case found of
+        Nothing -> False
+        Just v2 -> f v1 v2 && go l1 lt && go r1' gt
+    go (Leaf lk1 lv1) (Leaf lk2 lv2) = lk1 == lk2 && f lv1 lv2
+    go (Leaf lk lv) i@(Internal _ _ _ _) =
+      lookupWith False (f lv) lk (CritBit i)
+    go Empty _ = True
+    go _ _ = False
+{-# INLINABLE isSubmapOfBy #-}
 
 -- | /O(log n)/. The minimal key of the map. Calls 'error' if the map
 -- is empty.

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -122,9 +122,9 @@ module Data.CritBit.Tree
     , splitLookup
 
     -- * Submap
-    -- , isSubmapOf
     -- , isProperSubmapOf
     -- , isProperSubmapOfBy
+    , isSubmapOf
     , isSubmapOfBy
 
     -- -- * Min\/Max
@@ -678,6 +678,13 @@ splitLookup k (CritBit root) =
         EQ -> (Empty, Just lv, Empty)
     go _ = (Empty, Nothing, Empty)
 {-# INLINABLE splitLookup #-}
+
+-- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
+-- This function is defined as (@'isSubmapOf' = 'isSubmapOfBy' (==)@).
+--
+isSubmapOf :: (CritBitKey k, Eq v) => CritBit k v -> CritBit k v -> Bool
+isSubmapOf = isSubmapOfBy (==)
+{-# INLINABLE isSubmapOf #-}
 
 {- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
  The expression (@'isSubmapOfBy' f t1 t2@) returns 'True' if

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -366,6 +366,10 @@ main = do
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
         ]
+      , bgroup "isProperSubmapOf" $ [
+          bench "critbit" $ whnf (C.isProperSubmapOf b_critbit_1) b_critbit
+        , bench "map" $ whnf (Map.isProperSubmapOf b_map_1) b_map
+        ]
       , bgroup "isProperSubmapOfBy" $ [
           bench "critbit" $
             whnf (C.isProperSubmapOfBy (<=) b_critbit_1) b_critbit

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -358,6 +358,10 @@ main = do
           bench "critbit" $ whnf (forceTuple . C.splitLookup key) b_critbit
         , bench "map" $ whnf (forceTuple . Map.splitLookup key) b_map
         ]
+      , bgroup "isSubmapOf" $ [
+          bench "critbit" $ whnf (C.isSubmapOf b_critbit_1) b_critbit
+        , bench "map" $ whnf (Map.isSubmapOf b_map_1) b_map
+        ]
       , bgroup "isSubmapOfBy" $ [
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -358,6 +358,10 @@ main = do
           bench "critbit" $ whnf (forceTuple . C.splitLookup key) b_critbit
         , bench "map" $ whnf (forceTuple . Map.splitLookup key) b_map
         ]
+      , bgroup "isSubmapOfBy" $ [
+          bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
+        , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -366,6 +366,12 @@ main = do
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
         ]
+      , bgroup "isProperSubmapOfBy" $ [
+          bench "critbit" $
+            whnf (C.isProperSubmapOfBy (<=) b_critbit_1) b_critbit
+        , bench "map" $
+            whnf (Map.isProperSubmapOfBy (<=) b_map_1) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -338,6 +338,23 @@ t_splitLookup_missing k (KV kvs) =
             (C.splitLookup k) (Map.splitLookup k) k
             (KV (filter ((/=k) . fst) kvs))
 
+t_submap_general :: (CritBitKey k, Ord k) =>
+                    (CritBit k V -> CritBit k V -> Bool)
+                    -> (Map k V -> Map k V -> Bool)
+                    -> KV k -> KV k -> Bool
+t_submap_general cf mf (KV kvs1) (KV kvs2) =
+  cf (C.fromList kvs1) (C.fromList kvs2) ==
+  mf (Map.fromList kvs1) (Map.fromList kvs2)
+
+t_isSubmapOfBy_true :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_isSubmapOfBy_true _ (KV kvs1) (KV kvs2) =
+  C.isSubmapOfBy (<=) (C.fromList kvs1)
+                      (C.fromList $ kvs2 ++ (fmap (second (+1)) kvs1))
+
+t_isSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_isSubmapOfBy_ambiguous _ kvs1 kvs2 =
+  t_submap_general (C.isSubmapOfBy (<=)) (Map.isSubmapOfBy (<=)) kvs1 kvs2
+
 t_findMin :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_findMin k w@(KV kvs) =
   null kvs || isoWith id id C.findMin Map.findMin k w
@@ -524,6 +541,8 @@ propertiesFor t = [
   , testProperty "t_split_missing" $ t_split_missing t
   , testProperty "t_splitLookup_present" $ t_split_present t
   , testProperty "t_splitLookup_missing" $ t_split_missing t
+  , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
+  , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t
   , testProperty "t_findMax" $ t_findMax t
   , testProperty "t_deleteMin" $ t_deleteMin t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -346,6 +346,10 @@ t_submap_general cf mf (KV kvs1) (KV kvs2) =
   cf (C.fromList kvs1) (C.fromList kvs2) ==
   mf (Map.fromList kvs1) (Map.fromList kvs2)
 
+t_isSubmap_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_isSubmap_ambiguous _ kvs1 kvs2 =
+  t_submap_general C.isSubmapOf Map.isSubmapOf kvs1 kvs2
+
 t_isSubmapOfBy_true :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_isSubmapOfBy_true _ (KV kvs1) (KV kvs2) =
   C.isSubmapOfBy (<=) (C.fromList kvs1)
@@ -541,6 +545,7 @@ propertiesFor t = [
   , testProperty "t_split_missing" $ t_split_missing t
   , testProperty "t_splitLookup_present" $ t_split_present t
   , testProperty "t_splitLookup_missing" $ t_split_missing t
+  , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -359,6 +359,13 @@ t_isSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_isSubmapOfBy_ambiguous _ kvs1 kvs2 =
   t_submap_general (C.isSubmapOfBy (<=)) (Map.isSubmapOfBy (<=)) kvs1 kvs2
 
+t_isProperSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) =>
+                                  k -> KV k -> KV k -> Bool
+t_isProperSubmapOfBy_ambiguous _ kvs1 kvs2 =
+  t_submap_general (C.isProperSubmapOfBy (<=))
+                   (Map.isProperSubmapOfBy (<=))
+                   kvs1 kvs2
+
 t_findMin :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_findMin k w@(KV kvs) =
   null kvs || isoWith id id C.findMin Map.findMin k w
@@ -548,6 +555,8 @@ propertiesFor t = [
   , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
+  , testProperty "t_isProperSubmapOfBy_ambiguous" $
+      t_isProperSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t
   , testProperty "t_findMax" $ t_findMax t
   , testProperty "t_deleteMin" $ t_deleteMin t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -359,6 +359,11 @@ t_isSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_isSubmapOfBy_ambiguous _ kvs1 kvs2 =
   t_submap_general (C.isSubmapOfBy (<=)) (Map.isSubmapOfBy (<=)) kvs1 kvs2
 
+t_isProperSubmapOf_ambiguous :: (CritBitKey k, Ord k) =>
+                              k -> KV k -> KV k -> Bool
+t_isProperSubmapOf_ambiguous _ kvs1 kvs2 =
+  t_submap_general C.isProperSubmapOf Map.isProperSubmapOf kvs1 kvs2
+
 t_isProperSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) =>
                                   k -> KV k -> KV k -> Bool
 t_isProperSubmapOfBy_ambiguous _ kvs1 kvs2 =
@@ -555,6 +560,8 @@ propertiesFor t = [
   , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
+  , testProperty "t_isProperSubmapOf_ambiguous" $
+      t_isProperSubmapOf_ambiguous t
   , testProperty "t_isProperSubmapOfBy_ambiguous" $
       t_isProperSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t


### PR DESCRIPTION
Another place where the absence of an explicit key in the nodes hurts CritBit trees: all these are 50-100% slower than their Data.Map counterpart, primarily as a consequence of my having to traverse and rebuild the first tree to get a middle-ish key (an approach without `splitLookup`, using the entire right tree when it cannot be proved that the left tree is a subset of one of its branches, performs even worse). The benchmarking is also somewhat favorable to CritBit trees, as Maps keep size information in the nodes and can return immediately if the sizes are wrong.

I am in particular doubtful of my proper submap implementations; the method for tracking size seems somewhat kludgy (but performs somewhat better than checking sizes separately).

I based complexities on a worst-case complexity of `deleteFindMin` and `splitLookup` of _O(n)_; on a balanced tree they should be _O(log n)_ and the submap functions should be _O(m log m + n log n)_.
