### PR TITLE
Implemented lookupGE, lookupLT and lookupLE

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -21,7 +21,9 @@ module Data.CritBit.Tree
     , lookup
     , findWithDefault
     , lookupGT
-    -- , lookupGE
+    , lookupGE
+    , lookupLT
+    , lookupLE
 
     -- * Construction
     , empty
@@ -325,37 +327,76 @@ findWithDefault :: (CritBitKey k) =>
 findWithDefault d k m = lookupWith d id k m
 {-# INLINABLE findWithDefault #-}
 
--- | /O(log n)/. Find smallest key greater than the given one and
+-- | /O(k)/. Find smallest key greater than the given one and
 -- return the corresponding (key, value) pair.
 --
 -- > lookupGT "aa" (fromList [("a",3), ("b",5)]) == Just ("b",5)
 -- > lookupGT "b"  (fromList [("a",3), ("b",5)]) == Nothing
 lookupGT :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
-lookupGT k (CritBit root) = go root
+lookupGT k r = lookupOrd (LT ==) k r
+{-# INLINABLE lookupGT #-}
+
+-- | /O(k)/. Find smallest key greater than or equal to the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupGE "aa" (fromList [("a",3), ("b",5)]) == Just("b",5)
+-- > lookupGE "b"  (fromList [("a",3), ("b",5)]) == Just("b",5)
+-- > lookupGE "bb" (fromList [("a",3), ("b",5)]) == Nothing
+lookupGE :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupGE k r = lookupOrd (GT /=) k r
+{-# INLINABLE lookupGE #-}
+
+-- | /O(k)/. Find largest key smaller than the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupLT "aa" (fromList [("a",3), ("b",5)]) == Just ("a",3)
+-- > lookupLT "a"  (fromList [("a",3), ("b",5)]) == Nothing
+lookupLT :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupLT k r = lookupOrd (GT ==) k r
+{-# INLINABLE lookupLT #-}
+
+-- | /O(k)/. Find lagest key smaller than or equal to the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupGE "bb" (fromList [("aa",3), ("b",5)]) == Just("b",5)
+-- > lookupGE "aa" (fromList [("aa",3), ("b",5)]) == Just("aa",5)
+-- > lookupGE "a"  (fromList [("aa",3), ("b",5)]) == Nothing
+lookupLE :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupLE k r = lookupOrd (LT /=) k r
+{-# INLINABLE lookupLE #-}
+
+-- | /O(k)/. Common part of lookupXX functions.
+lookupOrd :: (CritBitKey k) => (Ordering -> Bool) -> k -> CritBit k v -> Maybe (k, v)
+lookupOrd selector k (CritBit root) = go root
   where
+    go Empty = Nothing
     go i@(Internal left right _ _)
       | direction k i == 0 = go left
       | otherwise          = go right
     go (Leaf lk lv)        = rewalk root
       where
-        finish (Leaf _ _) = case byteCompare k lk of
-                              LT -> Just (lk, lv)
-                              _ -> Nothing
+        finish (Leaf _ _) 
+          | selector (byteCompare k lk) = Just (lk, lv)
+          | otherwise                   = Nothing
         finish node
-          | calcDirection nob c == 0 = Nothing
-          | otherwise                = leftmost Nothing pair node
+          | calcDirection nob c == 0 = contGT node
+          | otherwise                = contLT node
+
         rewalk i@(Internal left right byte otherBits)
           | byte > n                     = finish i
           | byte == n && otherBits > nob = finish i
-          | direction k i == 0       = case rewalk left of
-                                        Nothing -> leftmost Nothing pair right
-                                        wat     -> wat
-          | otherwise                    = rewalk right
+          | direction k i == 0           = rewalk left  <|> contLT right
+          | otherwise                    = rewalk right <|> contGT left
         rewalk i                         = finish i
+
         (n, nob, c) = followPrefixes k lk
         pair a b = Just (a, b)
-    go Empty = Nothing
-{-# INLINABLE lookupGT #-}
+        contLT node = cont LT  leftmost node
+        contGT node = cont GT rightmost node
+        cont v f node
+          | selector v = f Nothing pair node 
+          | otherwise  = Nothing
+{-# INLINABLE lookupOrd #-}
 
 byteCompare :: (CritBitKey k) => k -> k -> Ordering
 byteCompare a b = go 0

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -307,6 +307,18 @@ main = do
           bench "critbit" $ whnf (C.lookupGT key) b_critbit
         , bench "map" $ whnf (Map.lookupGT key) b_map
         ]
+      , bgroup "lookupGE" $ [
+          bench "critbit" $ whnf (C.lookupGE key) b_critbit
+        , bench "map" $ whnf (Map.lookupGE key) b_map
+        ]
+      , bgroup "lookupLT" $ [
+          bench "critbit" $ whnf (C.lookupLT key) b_critbit
+        , bench "map" $ whnf (Map.lookupLT key) b_map
+        ]
+      , bgroup "lookupLE" $ [
+          bench "critbit" $ whnf (C.lookupLE key) b_critbit
+        , bench "map" $ whnf (Map.lookupLE key) b_map
+        ]
 #endif
       , bgroup "member" $ keyed C.member Map.member H.member Trie.member
       , bgroup "foldlWithKey'" $ let f a _ b = a + b

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -86,6 +86,18 @@ t_lookup_missing _ k (CB m) = C.lookup k (C.delete k m) == Nothing
 t_lookupGT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
 t_lookupGT _ k (KV kvs) =
     C.lookupGT k (C.fromList kvs) == Map.lookupGT k (Map.fromList kvs)
+
+t_lookupGE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
+t_lookupGE _ k (KV kvs) =
+    C.lookupGE k (C.fromList kvs) == Map.lookupGE k (Map.fromList kvs)
+
+t_lookupLT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
+t_lookupLT _ k (KV kvs) =
+    C.lookupLT k (C.fromList kvs) == Map.lookupLT k (Map.fromList kvs)
+
+t_lookupLE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
+t_lookupLE _ k (KV kvs) =
+    C.lookupLE k (C.fromList kvs) == Map.lookupLE k (Map.fromList kvs)
 #endif
 
 -- Test that the behaviour of a CritBit function is the same as that
@@ -575,6 +587,9 @@ propertiesFor t = [
   , testProperty "t_lookup_missing" $ t_lookup_missing t
 #if MIN_VERSION_containers(0,5,0)
   , testProperty "t_lookupGT" $ t_lookupGT t
+  , testProperty "t_lookupGE" $ t_lookupGE t
+  , testProperty "t_lookupLT" $ t_lookupLT t
+  , testProperty "t_lookupLE" $ t_lookupLE t
 #endif
   , testProperty "t_delete_present" $ t_delete_present t
   , testProperty "t_adjust_present" $ t_updateWithKey_present t


### PR DESCRIPTION
Alternative to [Pull Request #33](https://github.com/bos/critbit/pull/33) (sorry, @archblob)

All `lookupXX` implementations based on generic `lookupOrd` function. 
