### PR TITLE
Implemented isSubmap, isSubmapBy, isProperSubMap, isProperSubmapBy

### DIFF
--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -122,9 +122,9 @@ module Data.CritBit.Tree
     , splitLookup
 
     -- * Submap
-    -- , isSubmapOf
     -- , isProperSubmapOf
     -- , isProperSubmapOfBy
+    , isSubmapOf
     , isSubmapOfBy
 
     -- -- * Min\/Max
@@ -1043,6 +1043,13 @@ splitLookup k (CritBit root) =
         EQ -> (Empty, Just lv, Empty)
     go _ = (Empty, Nothing, Empty)
 {-# INLINABLE splitLookup #-}
+
+-- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
+-- This function is defined as (@'isSubmapOf' = 'isSubmapOfBy' (==)@).
+--
+isSubmapOf :: (CritBitKey k, Eq v) => CritBit k v -> CritBit k v -> Bool
+isSubmapOf = isSubmapOfBy (==)
+{-# INLINABLE isSubmapOf #-}
 
 {- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
  The expression (@'isSubmapOfBy' f t1 t2@) returns 'True' if

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -122,9 +122,9 @@ module Data.CritBit.Tree
     , splitLookup
 
     -- * Submap
-    -- , isProperSubmapOf
     , isSubmapOf
     , isSubmapOfBy
+    , isProperSubmapOf
     , isProperSubmapOfBy
 
     -- -- * Min\/Max
@@ -1083,6 +1083,13 @@ isSubmapOfBy f (CritBit root1) (CritBit root2) = go root1 root2
     go Empty _ = True
     go _ _ = False
 {-# INLINABLE isSubmapOfBy #-}
+
+-- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
+-- Is this a proper submap? (ie. a submap but not equal).
+-- Defined as (@'isProperSubmapOf' = 'isProperSubmapOfBy' (==)@).
+isProperSubmapOf :: (CritBitKey k, Eq v) => CritBit k v -> CritBit k v -> Bool
+isProperSubmapOf = isProperSubmapOfBy (==)
+{-# INLINABLE isProperSubmapOf #-}
 
 data ProperBool = NotTrue
                 | TrueImp

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -123,9 +123,9 @@ module Data.CritBit.Tree
 
     -- * Submap
     -- , isProperSubmapOf
-    -- , isProperSubmapOfBy
     , isSubmapOf
     , isSubmapOfBy
+    , isProperSubmapOfBy
 
     -- -- * Min\/Max
     , findMin
@@ -1083,6 +1083,59 @@ isSubmapOfBy f (CritBit root1) (CritBit root2) = go root1 root2
     go Empty _ = True
     go _ _ = False
 {-# INLINABLE isSubmapOfBy #-}
+
+data ProperBool = NotTrue
+                | TrueImp
+                | TrueProp
+
+addPB :: ProperBool -> ProperBool -> ProperBool
+addPB NotTrue _ = NotTrue
+addPB _ NotTrue = NotTrue
+addPB TrueProp _ = TrueProp
+addPB _ TrueProp = TrueProp
+addPB _ _ = TrueImp
+
+toBool :: ProperBool -> Bool
+toBool TrueProp = True
+toBool _ = False
+
+{- | /O(m^2+mn)/ (where /m/ is the first map and /n/ the second).
+ Is this a proper submap? (ie. a submap but not equal).
+ The expression (@'isProperSubmapOfBy' f m1 m2@) returns 'True' when
+ @m1@ and @m2@ are not equal,
+ all keys in @m1@ are in @m2@, and when @f@ returns 'True' when
+ applied to their respective values. For example, the following
+ expressions are all 'True':
+
+  > isProperSubmapOfBy (==) (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+  > isProperSubmapOfBy (<=) (fromList [("a",0)]) (fromList [("a",1),("b",2)])
+
+ But the following are all 'False':
+
+  > isProperSubmapOfBy (==) (fromList [("a",1),("b",2)]) (fromList [("a",1),("b",2)])
+  > isProperSubmapOfBy (==) (fromList ["a",1),("b",2)])  (fromList [("a",1)])
+  > isProperSubmapOfBy (<)  (fromList [("a",1)])         (fromList [("a",1),("b",2)])
+-}
+
+isProperSubmapOfBy :: (CritBitKey k) =>
+                      (a -> b -> Bool) -> CritBit k a -> CritBit k b -> Bool
+isProperSubmapOfBy f (CritBit root1) (CritBit root2) = toBool $ go root1 root2
+  where
+    go (Internal l1 r1 _ _) i2 =
+      let ((key,v1), CritBit r1') = deleteFindMin $ CritBit r1
+          (CritBit lt,found,CritBit gt) = splitLookup key $ CritBit i2
+      in case found of
+        Nothing -> NotTrue
+        Just v2 -> if f v1 v2 then go l1 lt `addPB` go r1' gt else NotTrue
+    go (Leaf lk1 lv1) (Leaf lk2 lv2) = if lk1 == lk2 && f lv1 lv2
+                                       then TrueImp else NotTrue
+    go (Leaf lk lv) i@(Internal _ _ _ _) =
+      lookupWith NotTrue (\v -> if f lv v then TrueProp else NotTrue)
+                 lk (CritBit i)
+    go Empty Empty = TrueImp
+    go Empty _ = TrueProp
+    go _ _ = NotTrue
+{-# INLINABLE isProperSubmapOfBy #-}
 
 -- | /O(log n)/. The minimal key of the map. Calls 'error' if the map
 -- is empty.

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -443,6 +443,10 @@ main = do
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
         ]
+      , bgroup "isProperSubmapOf" $ [
+          bench "critbit" $ whnf (C.isProperSubmapOf b_critbit_1) b_critbit
+        , bench "map" $ whnf (Map.isProperSubmapOf b_map_1) b_map
+        ]
       , bgroup "isProperSubmapOfBy" $ [
           bench "critbit" $
             whnf (C.isProperSubmapOfBy (<=) b_critbit_1) b_critbit

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -435,6 +435,10 @@ main = do
           bench "critbit" $ whnf (forceTriple . C.splitLookup key) b_critbit
         , bench "map" $ whnf (forceTriple . Map.splitLookup key) b_map
         ]
+      , bgroup "isSubmapOf" $ [
+          bench "critbit" $ whnf (C.isSubmapOf b_critbit_1) b_critbit
+        , bench "map" $ whnf (Map.isSubmapOf b_map_1) b_map
+        ]
       , bgroup "isSubmapOfBy" $ [
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -443,6 +443,12 @@ main = do
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
         ]
+      , bgroup "isProperSubmapOfBy" $ [
+          bench "critbit" $
+            whnf (C.isProperSubmapOfBy (<=) b_critbit_1) b_critbit
+        , bench "map" $
+            whnf (Map.isProperSubmapOfBy (<=) b_map_1) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -435,6 +435,10 @@ main = do
           bench "critbit" $ whnf (forceTriple . C.splitLookup key) b_critbit
         , bench "map" $ whnf (forceTriple . Map.splitLookup key) b_map
         ]
+      , bgroup "isSubmapOfBy" $ [
+          bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
+        , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
+        ]
       , bgroup "findMin" $ [
           bench "critbit" $ whnf (C.findMin) b_critbit
         , bench "map" $ whnf (Map.findMin) b_map

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -446,6 +446,11 @@ t_isSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_isSubmapOfBy_ambiguous _ kvs1 kvs2 =
   t_submap_general (C.isSubmapOfBy (<=)) (Map.isSubmapOfBy (<=)) kvs1 kvs2
 
+t_isProperSubmapOf_ambiguous :: (CritBitKey k, Ord k) =>
+                              k -> KV k -> KV k -> Bool
+t_isProperSubmapOf_ambiguous _ kvs1 kvs2 =
+  t_submap_general C.isProperSubmapOf Map.isProperSubmapOf kvs1 kvs2
+
 t_isProperSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) =>
                                   k -> KV k -> KV k -> Bool
 t_isProperSubmapOfBy_ambiguous _ kvs1 kvs2 =
@@ -656,6 +661,8 @@ propertiesFor t = [
   , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
+  , testProperty "t_isProperSubmapOf_ambiguous" $
+      t_isProperSubmapOf_ambiguous t
   , testProperty "t_isProperSubmapOfBy_ambiguous" $
       t_isProperSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -446,6 +446,13 @@ t_isSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_isSubmapOfBy_ambiguous _ kvs1 kvs2 =
   t_submap_general (C.isSubmapOfBy (<=)) (Map.isSubmapOfBy (<=)) kvs1 kvs2
 
+t_isProperSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) =>
+                                  k -> KV k -> KV k -> Bool
+t_isProperSubmapOfBy_ambiguous _ kvs1 kvs2 =
+  t_submap_general (C.isProperSubmapOfBy (<=))
+                   (Map.isProperSubmapOfBy (<=))
+                   kvs1 kvs2
+
 t_findMin :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_findMin k w@(KV kvs) =
   null kvs || isoWith id id C.findMin Map.findMin k w
@@ -649,6 +656,8 @@ propertiesFor t = [
   , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
+  , testProperty "t_isProperSubmapOfBy_ambiguous" $
+      t_isProperSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t
   , testProperty "t_findMax" $ t_findMax t
   , testProperty "t_deleteMin" $ t_deleteMin t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -425,6 +425,23 @@ t_splitLookup_missing k (KV kvs) =
             (C.splitLookup k) (Map.splitLookup k) k
             (KV (filter ((/=k) . fst) kvs))
 
+t_submap_general :: (CritBitKey k, Ord k) =>
+                    (CritBit k V -> CritBit k V -> Bool)
+                    -> (Map k V -> Map k V -> Bool)
+                    -> KV k -> KV k -> Bool
+t_submap_general cf mf (KV kvs1) (KV kvs2) =
+  cf (C.fromList kvs1) (C.fromList kvs2) ==
+  mf (Map.fromList kvs1) (Map.fromList kvs2)
+
+t_isSubmapOfBy_true :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_isSubmapOfBy_true _ (KV kvs1) (KV kvs2) =
+  C.isSubmapOfBy (<=) (C.fromList kvs1)
+                      (C.fromList $ kvs2 ++ (fmap (second (+1)) kvs1))
+
+t_isSubmapOfBy_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_isSubmapOfBy_ambiguous _ kvs1 kvs2 =
+  t_submap_general (C.isSubmapOfBy (<=)) (Map.isSubmapOfBy (<=)) kvs1 kvs2
+
 t_findMin :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_findMin k w@(KV kvs) =
   null kvs || isoWith id id C.findMin Map.findMin k w
@@ -625,6 +642,8 @@ propertiesFor t = [
   , testProperty "t_split_missing" $ t_split_missing t
   , testProperty "t_splitLookup_present" $ t_split_present t
   , testProperty "t_splitLookup_missing" $ t_split_missing t
+  , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
+  , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t
   , testProperty "t_findMax" $ t_findMax t
   , testProperty "t_deleteMin" $ t_deleteMin t

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -433,6 +433,10 @@ t_submap_general cf mf (KV kvs1) (KV kvs2) =
   cf (C.fromList kvs1) (C.fromList kvs2) ==
   mf (Map.fromList kvs1) (Map.fromList kvs2)
 
+t_isSubmap_ambiguous :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
+t_isSubmap_ambiguous _ kvs1 kvs2 =
+  t_submap_general C.isSubmapOf Map.isSubmapOf kvs1 kvs2
+
 t_isSubmapOfBy_true :: (CritBitKey k, Ord k) => k -> KV k -> KV k -> Bool
 t_isSubmapOfBy_true _ (KV kvs1) (KV kvs2) =
   C.isSubmapOfBy (<=) (C.fromList kvs1)
@@ -642,6 +646,7 @@ propertiesFor t = [
   , testProperty "t_split_missing" $ t_split_missing t
   , testProperty "t_splitLookup_present" $ t_split_present t
   , testProperty "t_splitLookup_missing" $ t_split_missing t
+  , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_findMin" $ t_findMin t


### PR DESCRIPTION
Based on pull request #55 by @isturdy.

Implementations of `isSubmapBy` and `isProperSubmapBy` made mutually recursive. This implementation is 25% faster than in `Data.Map`.

This pull request is partially unifiable with requests #53 and #54.
