### PR TITLE
Implemented `fromAscList` and `fromDistinctAscList`

### DIFF
--- a/Data/CritBit/Core.hs
+++ b/Data/CritBit/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module      :  Data.CritBit.Tree
 -- Copyright   :  (c) Bryan O'Sullivan 2013
@@ -160,7 +161,7 @@ followPrefixesFrom :: (CritBitKey k) =>
                    -> k             -- ^ First key.
                    -> k             -- ^ Second key.
                    -> (Int, BitMask, Word16)
-followPrefixesFrom position k l = (n, maskLowerBits (b `xor` c), c)
+followPrefixesFrom !position !k !l = (n, maskLowerBits (b `xor` c), c)
   where
     n = followPrefixesByteFrom position k l
     b = getByte k n
@@ -182,12 +183,10 @@ followPrefixesByteFrom :: (CritBitKey k) =>
                        -> k             -- ^ First key.
                        -> k             -- ^ Second key.
                        -> Int
-followPrefixesByteFrom position k l = go position
+followPrefixesByteFrom !position !k !l = go position
   where
-    go n | b /= c    = n
-         | b == 0    = n
-         | c == 0    = n
-         | otherwise = go (n+1)
+    go !n | b /= c || b == 0 || c == 0 = n
+          | otherwise                  = go (n + 1)
       where b = getByte k n
             c = getByte l n
 {-# INLINE followPrefixesByteFrom #-}

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -102,6 +102,8 @@ main = do
                      "to use it for benchmark data)")
                ioError err
   let b_ordKVs = zip ordKeys [(0::Int)..]
+      prefix = B.concat $ L.map fst b_ordKVs
+      b_longKVs = map (first (B.append prefix)) b_ordKVs
       b_revKVs = reverse b_ordKVs
   b_randKVs <- do
     gen <- create
@@ -354,9 +356,13 @@ main = do
         ]
       , bgroup "toAscList" $ function nf C.toAscList Map.toAscList id id
       , bgroup "toDescList" $ function nf C.toDescList Map.toDescList id id
-      , bgroup "fromAscList" [
-          bench "critbit" $ whnf   C.fromAscList b_ordKVs
-        , bench "map"     $ whnf Map.fromAscList b_ordKVs
+      , bgroup "fromAscList_short" [
+          bench "critbit" $ nf   C.fromAscList b_ordKVs
+        , bench "map"     $ nf Map.fromAscList b_ordKVs
+        ]
+      , bgroup "fromAscList_long" [
+          bench "critbit" $ nf   C.fromAscList b_longKVs
+        , bench "map"     $ nf Map.fromAscList b_longKVs
         ]
       , bgroup "fromAscListWith" [
           bench "critbit" $ nf (  C.fromAscListWith (+)) b_ordKVs
@@ -370,12 +376,9 @@ main = do
           bench "critbit" $ nf (  C.fromDistinctAscList) b_ordKVs
         , bench "map"     $ nf (Map.fromDistinctAscList) b_ordKVs
         ]
-      , bgroup "fromAscDistinctList_long" $ let
-          prefix = B.concat $ L.map fst b_ordKVs
-          b_KVs = map (first (B.append prefix)) b_ordKVs
-        in [
-          bench "critbit" $ nf (  C.fromDistinctAscList) b_KVs
-        , bench "map"     $ nf (Map.fromDistinctAscList) b_KVs
+      , bgroup "fromAscDistinctList_long" [
+          bench "critbit" $ nf (  C.fromDistinctAscList) b_longKVs
+        , bench "map"     $ nf (Map.fromDistinctAscList) b_longKVs
         ]
       , bgroup "filter" $ let p  = (< 128)
                               p' = \e -> if p e then Just e else Nothing

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -46,6 +46,7 @@ library
     bytestring >= 0.9,
     deepseq,
     text >= 0.11.2.3,
+    array,
     vector
 
   ghc-options: -Wall -funbox-strict-fields -O2 -fwarn-tabs

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -14,7 +14,8 @@ import Data.Foldable (foldMap)
 import Data.Functor.Identity (Identity(..))
 #endif
 
-import Data.List (unfoldr)
+import Data.List (unfoldr, sort, nubBy)
+import Data.Function (on)
 import Data.Map (Map)
 import Data.Monoid (Sum(..))
 import Data.String (IsString, fromString)
@@ -347,6 +348,33 @@ t_toAscList = isoWith C.toAscList Map.toAscList id id
 t_toDescList :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_toDescList = isoWith C.toDescList Map.toDescList id id
 
+-- Check that 'toList's are equal, with input preprocessing
+(====) :: (CritBitKey k, Ord k) =>
+          ([(k, V)] -> CritBit k V) -> ([(k, V)] -> Map k V)
+       -> ([(k, V)] -> [(k, V)]) -> KV k -> Bool
+(====) f g p (KV kvs) = C.toList (f kvs') == Map.toList (g kvs')
+  where
+    kvs' = p kvs
+
+t_fromAscList :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_fromAscList _ = (C.fromAscList ==== Map.fromAscList) sort
+
+t_fromAscListWith :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_fromAscListWith _ =
+    (C.fromAscListWith (+) ==== Map.fromAscListWith (+)) sort
+
+t_fromAscListWithKey :: (CritBitKey k, Ord k) => k -> KV k -> Bool
+t_fromAscListWithKey _ =
+    (C.fromAscListWithKey f ==== Map.fromAscListWithKey f) sort
+  where
+    f k v1 v2 = fromIntegral (C.byteCount k) + v1 + 2 * v2
+
+t_fromDistinctAscList :: (CritBitKey k, Ord k) => k -> k -> V -> KV k -> Bool
+t_fromDistinctAscList _ k v =
+    ((( C.insert k v) .   C.fromDistinctAscList) ====
+    ((Map.insert k v) . Map.fromDistinctAscList))
+    (nubBy ((==) `on` fst) . sort)
+
 t_filter :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_filter = C.filter p === Map.filter p
   where p = (> (maxBound - minBound) `div` 2)
@@ -545,6 +573,10 @@ propertiesFor t = [
   , testProperty "t_mapAccumRWithKey"$ t_mapAccumRWithKey t
   , testProperty "t_toAscList" $ t_toAscList t
   , testProperty "t_toDescList" $ t_toDescList t
+  , testProperty "t_fromAscList" $ t_fromAscList t
+  , testProperty "t_fromAscListWith" $ t_fromAscListWith t
+  , testProperty "t_fromAscListWithKey" $ t_fromAscListWithKey t
+  , testProperty "t_fromDistinctAscList" $ t_fromDistinctAscList t
   , testProperty "t_insertWithKey_present" $ t_insertWithKey_present t
   , testProperty "t_insertWithKey_missing" $ t_insertWithKey_missing t
   , testProperty "t_filter" $ t_filter t


### PR DESCRIPTION
This implementation is suffering from ineffective duplicates removal in `fromAscListWithKey`and not optimal usage of common prefixes in `fromDistinctAscList`.

Anyway, all functions runs in linear time both by the number of keys and total key length: _O(n+K)_.

**Note** `Data.Map` functions runs much faster, because it does not not looks at keys at all.
