### PR TITLE
Implement insertLookupWithKey and rewrite insert functions.

### DIFF
--- a/Data/CritBit/Core.hs
+++ b/Data/CritBit/Core.hs
@@ -50,30 +50,7 @@ import Data.Word (Word16)
 -- > insertWithKey f "a" 1 empty                         == singleton "a" 1
 insertWithKey :: CritBitKey k => (k -> v -> v -> v) -> k -> v -> CritBit k v
               -> CritBit k v
-insertWithKey f k v (CritBit root) = CritBit . go $ root
-  where
-    go i@(Internal left right _ _)
-      | direction k i == 0 = go left
-      | otherwise          = go right
-    go (Leaf lk _)         = rewalk root
-      where
-        rewalk i@(Internal left right byte otherBits)
-          | byte > n                     = finish i
-          | byte == n && otherBits > nob = finish i
-          | direction k i == 0           = i { ileft = rewalk left }
-          | otherwise                    = i { iright = rewalk right }
-        rewalk i                         = finish i
-
-        finish (Leaf _ v') | k == lk = Leaf k (f k v v')
-        finish node
-          | nd == 0   = Internal { ileft = node, iright = Leaf k v,
-                                   ibyte = n, iotherBits = nob }
-          | otherwise = Internal { ileft = Leaf k v, iright = node,
-                                   ibyte = n, iotherBits = nob }
-
-        (n, nob, c) = followPrefixes k lk
-        nd          = calcDirection nob c
-    go Empty = Leaf k v
+insertWithKey f k v m = insertLookupGen (flip const) f k v m
 {-# INLINABLE insertWithKey #-}
 
 -- | /O(log n)/. Combines insert operation with old value retrieval.

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -1360,7 +1360,7 @@ insert = insertLookupGen (flip const) (\_ v _ -> v)
 -- > insertWith (+) "x" 5 empty                         == singleton "x" 5
 --
 insertWith :: CritBitKey k => (v -> v -> v) -> k -> v -> CritBit k v -> CritBit k v
-insertWith f = insertWithKey (\_ v v' -> f v v')
+insertWith f = insertLookupGen (flip const) (\_ v v' -> f v v')
 {-# INLINABLE insertWith #-}
 
 -- | /O(n)/. Apply a function to all values.

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -1346,7 +1346,7 @@ updateMaxWithKey maybeUpdate (CritBit root) = CritBit $ go root
 -- > insert "x" 7 (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3), ("x",7)]
 -- > insert "x" 5 empty                         == singleton "x" 5
 insert :: (CritBitKey k) => k -> v -> CritBit k v -> CritBit k v
-insert = insertWithKey (\_ v _ -> v)
+insert = insertLookupGen (flip const) (\_ v _ -> v)
 {-# INLINABLE insert #-}
 
 -- | /O(log n)/. Insert with a function, combining new value and old value.

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -33,7 +33,7 @@ module Data.CritBit.Tree
     , insert
     , insertWith
     , insertWithKey
-    -- , insertLookupWithKey
+    , insertLookupWithKey
 
     -- * Deletion
     , delete

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -47,7 +47,7 @@ instance NFData B.ByteString
 instance (NFData a) => NFData (Trie.Trie a) where
     rnf = rnf . Trie.toList
 
-forcePair:: (a,a) -> ()
+forcePair:: (a,b) -> ()
 forcePair (a,b) = a `seq` b `seq` ()
 
 every k = go 0
@@ -232,6 +232,20 @@ main = do
         , bgroup "missing" [
             bench "critbit" $ whnf (C.insertWithKey f key 1) b_critbit_1
           , bench "map" $ whnf (Map.insertWithKey f key 1) b_map_1
+          ]
+        ]
+      , bgroup "insertLookupWithKey" $ let f _ a b = a + b in [
+          bgroup "present" [
+            bench "critbit" $
+                whnf (forcePair . C.insertLookupWithKey f key 1) b_critbit
+          , bench "map" $
+                whnf (forcePair . Map.insertLookupWithKey f key 1) b_map
+          ]
+        , bgroup "missing" [
+            bench "critbit" $
+                whnf (forcePair . C.insertLookupWithKey f key 1) b_critbit_1
+          , bench "map" $
+                whnf (forcePair . Map.insertLookupWithKey f key 1) b_map_1
           ]
         ]
       , bgroup "adjust" $

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -562,6 +562,15 @@ t_insertWithKey_missing _ k v (KV kvs) = Map.toList m == C.toList c
     m = Map.insertWithKey f k v $ Map.fromList kvs
     c =   C.insertWithKey f k v $   C.fromList kvs
 
+t_insertLookupWithKey :: (CritBitKey k, Ord k)
+                      => k -> k -> V -> KV k -> Bool
+t_insertLookupWithKey _ k v (KV kvs) = m == c
+  where
+    fixup tl (a,b) = (a,tl b)
+    f _ v1 v2 = v1 + v2
+    m = fixup Map.toList . Map.insertLookupWithKey f k v $ Map.fromList kvs
+    c = fixup C.toList . C.insertLookupWithKey f k v $ C.fromList kvs
+
 t_foldMap :: (CritBitKey k, Ord k) => k -> KV k -> Bool
 t_foldMap = isoWith (foldMap Sum) (foldMap Sum) id id
 
@@ -668,6 +677,7 @@ propertiesFor t = [
   , testProperty "t_fromDistinctAscList" $ t_fromDistinctAscList t
   , testProperty "t_insertWithKey_present" $ t_insertWithKey_present t
   , testProperty "t_insertWithKey_missing" $ t_insertWithKey_missing t
+  , testProperty "t_insertLookupWithKey" $ t_insertLookupWithKey t
   , testProperty "t_filter" $ t_filter t
   , testProperty "t_split_present" $ t_split_present t
   , testProperty "t_split_missing" $ t_split_missing t
@@ -698,6 +708,7 @@ propertiesFor t = [
   , testProperty "t_insertWith_missing" $ t_insertWith_missing t
   , testProperty "t_insertWithKey_present" $ t_insertWithKey_present t
   , testProperty "t_insertWithKey_missing" $ t_insertWithKey_missing t
+  , testProperty "t_insertLookupWithKey" $ t_insertLookupWithKey t
 #if MIN_VERSION_containers(0,5,0)
   , testProperty "t_traverseWithKey" $ t_traverseWithKey t
 #endif


### PR DESCRIPTION
I rewrote all insert functions in terms of more general `insertLookupGen`` and we gain a little more speed.
The new benchmarks(all upper bounds):

```
insert -- old
Mean execution time : 400.6 ns
Standard deviation  : 78.50 ns

insert -- new
Mean execution time : 304.7 ns
Standard deviation  : 30.69 ns
```

```
insertWith -- old
Mean execution time : 388.3 ns
Standard deviation  : 57.18 ns

insertWith -- new
Mean execution time : 328.6 ns
Standard deviation  : 66.93 ns
```

```
insertWithKey -- old
Mean execution time : 391.0 ns
Standard deviation  : 64.12 ns

insertWithKey -- new
Mean execution time : 320.8 ns
Standard deviation  : 57.22 ns
```

Also, if I did not mess the benchmarks again `insertLookupWithKey` is almost three times faster than the containers function.
