### PR TITLE
Tests updated

### DIFF
--- a/Data/CritBit/Set.hs
+++ b/Data/CritBit/Set.hs
@@ -326,9 +326,8 @@ map = wrapVS Set T.mapKeys
 -- > and [x < y ==> f x < f y | x <- ls, y <- ls]
 -- >                     ==> mapMonotonic f s == map f s
 -- >     where ls = toList s
-mapMonotonic :: (CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
-mapMonotonic = error "Depends on T.mapKeysMonotonic"
---mapMonotonic = wrapVS Set T.mapKeysMonotonic
+mapMonotonic :: (CritBitKey a1, CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
+mapMonotonic = wrapVS Set T.mapKeysMonotonic
 {-# INLINABLE mapMonotonic #-}
 
 -- | /O(n)/. Fold the elements in the set using the given left-associative

--- a/Data/CritBit/Set.hs
+++ b/Data/CritBit/Set.hs
@@ -326,8 +326,9 @@ map = wrapVS Set T.mapKeys
 -- > and [x < y ==> f x < f y | x <- ls, y <- ls]
 -- >                     ==> mapMonotonic f s == map f s
 -- >     where ls = toList s
-mapMonotonic :: (CritBitKey a1, CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
-mapMonotonic = wrapVS Set T.mapKeysMonotonic
+mapMonotonic :: (CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
+mapMonotonic = error "Depends on T.mapKeysMonotonic"
+--mapMonotonic = wrapVS Set T.mapKeysMonotonic
 {-# INLINABLE mapMonotonic #-}
 
 -- | /O(n)/. Fold the elements in the set using the given left-associative

--- a/Data/CritBit/Set.hs
+++ b/Data/CritBit/Set.hs
@@ -327,8 +327,7 @@ map = wrapVS Set T.mapKeys
 -- >                     ==> mapMonotonic f s == map f s
 -- >     where ls = toList s
 mapMonotonic :: (CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
-mapMonotonic = error "Depends on T.mapKeysMonotonic"
---mapMonotonic = wrapVS Set T.mapKeysMonotonic
+mapMonotonic = wrapVS Set T.mapKeysMonotonic
 {-# INLINABLE mapMonotonic #-}
 
 -- | /O(n)/. Fold the elements in the set using the given left-associative

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -845,7 +845,7 @@ mapKeysWith c f m = foldrWithKey ins empty m
 -- This function has slightly better performance than 'mapKeys'.
 --
 -- > mapKeysMonotonic (\ k -> succ k) (fromList [("a",5), ("b",3)]) == fromList [("b",5), ("c",3)]
-mapKeysMonotonic :: (CritBitKey k1, CritBitKey k2)
+mapKeysMonotonic :: (CritBitKey k2)
                  => (k1 -> k2) -> CritBit k1 v -> CritBit k2 v
 mapKeysMonotonic f m = foldlWithKey (insertRight f) empty m
 {-# INLINABLE mapKeysMonotonic #-}

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -64,6 +64,7 @@ test-suite tests
     other-modules:
       Properties.Common
       Properties.Map
+      Properties.Set
 
   ghc-options:
     -Wall -threaded -rtsopts -with-rtsopts=-N

--- a/tests/Properties/Common.hs
+++ b/tests/Properties/Common.hs
@@ -16,9 +16,11 @@ module Properties.Common
     , (=*==)
     , notEmpty
     , prepends
+    , kf
   ) where
 
-import Data.String (IsString)
+import Data.CritBit.Map.Lazy (CritBitKey, byteCount)
+import Data.String (IsString, fromString)
 import Data.Monoid (Monoid, mappend)
 import Control.Applicative ((<$>))
 import Test.QuickCheck (Arbitrary(..), Args(..), quickCheckWith, stdArgs)
@@ -106,6 +108,10 @@ notEmpty f t items = null items || f t items
 
 prepends :: (IsString k, Monoid k) => k -> k
 prepends = mappend "test"
+
+-- | Keys mapping function
+kf :: (CritBitKey k, IsString k, Monoid k) => k -> k
+kf k = fromString (show (byteCount k)) `mappend` k
 
 -- Handy functions for fiddling with from ghci.
 

--- a/tests/Properties/Common.hs
+++ b/tests/Properties/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, IncoherentInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Properties.Common
     (
@@ -14,8 +15,11 @@ module Properties.Common
     , (=**=)
     , (=*==)
     , notEmpty
+    , prepends
   ) where
 
+import Data.String (IsString)
+import Data.Monoid (Monoid, mappend)
 import Control.Applicative ((<$>))
 import Test.QuickCheck (Arbitrary(..), Args(..), quickCheckWith, stdArgs)
 import Test.QuickCheck.Gen (resize, sized)
@@ -100,8 +104,10 @@ data SameAs f g r = SameAs {
 notEmpty :: (SameAs c1 c2 [i] -> [i] -> Bool) -> SameAs c1 c2 [i] -> [i] -> Bool
 notEmpty f t items = null items || f t items
 
+prepends :: (IsString k, Monoid k) => k -> k
+prepends = mappend "test"
+
 -- Handy functions for fiddling with from ghci.
 
 qc :: Testable prop => Int -> prop -> IO ()
 qc n = quickCheckWith stdArgs { maxSuccess = n }
-

--- a/tests/Properties/Common.hs
+++ b/tests/Properties/Common.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, IncoherentInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, Rank2Types #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Properties.Common
     (
       Small(..)
     , qc
+    , Props
     , Eq'(..)
     , SameAs(..)
     , (=?=)
@@ -23,6 +24,7 @@ import Data.CritBit.Map.Lazy (CritBitKey, byteCount)
 import Data.String (IsString, fromString)
 import Data.Monoid (Monoid, mappend)
 import Control.Applicative ((<$>))
+import Test.Framework (Test)
 import Test.QuickCheck (Arbitrary(..), Args(..), quickCheckWith, stdArgs)
 import Test.QuickCheck.Gen (resize, sized)
 import Test.QuickCheck.Property (Testable)
@@ -45,6 +47,8 @@ instance (Show a, Arbitrary a) => Arbitrary (Small a) where
       where
         smallish = round . (sqrt :: Double -> Double) . fromIntegral . abs
     shrink = map Small . shrink . fromSmall
+
+type Props k = (Arbitrary k, CritBitKey k, Ord k, IsString k, Monoid k, Show k) => k -> [Test]
 
 infix 4 =^=, =?=, =??=
 

--- a/tests/Properties/Common.hs
+++ b/tests/Properties/Common.hs
@@ -1,48 +1,44 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
-{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, TypeFamilies #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, IncoherentInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Properties.Common
     (
       V
-    , KV(..)
     , Small(..)
     , unsquare
     , smallArbitrary
     , qc
     , Eq'(..)
+    , SameAs (..)
     , (=?=)
-    ) where
+    , (=??=)
+    , (=*=)
+    , (=?*=)
+    , (=??*=)
+    , (=**=)
+    , (=*==)
+    , notEmpty
+  ) where
 
 import Control.Applicative ((<$>))
-import Data.ByteString (ByteString)
 import Data.CritBit.Map.Lazy (CritBitKey, CritBit)
-import Data.Text (Text)
 import Data.Word (Word8)
 import Test.QuickCheck (Arbitrary(..), Args(..), quickCheckWith, stdArgs)
 import Test.QuickCheck.Gen (Gen, resize, sized)
 import Test.QuickCheck.Property (Property, Testable, forAll)
-import qualified Data.ByteString as BB
 import qualified Data.ByteString.Char8 as B
 import qualified Data.CritBit.Map.Lazy as C
 import qualified Data.CritBit.Set as CS
 import qualified Data.Text as T
 
-instance Arbitrary ByteString where
-    arbitrary = BB.pack <$> arbitrary
+instance Arbitrary B.ByteString where
+    arbitrary = B.pack <$> arbitrary
     shrink    = map B.pack . shrink . B.unpack
 
-instance Arbitrary Text where
+instance Arbitrary T.Text where
     arbitrary = T.pack <$> arbitrary
     shrink    = map T.pack . shrink . T.unpack
 
 type V = Word8
-
-newtype KV a = KV { fromKV :: [(a, V)] }
-        deriving (Show, Eq, Ord)
-
-instance Arbitrary a => Arbitrary (KV a) where
-    arbitrary = (KV . flip zip [0..]) <$> arbitrary
-    shrink = map (KV . flip zip [0..]) . shrink . map fst . fromKV
 
 instance (CritBitKey k, Arbitrary k, Arbitrary v) =>
   Arbitrary (CritBit k v) where
@@ -67,10 +63,12 @@ newtype Small a = Small { fromSmall :: a }
     deriving (Eq, Ord, Show)
 
 instance (Show a, Arbitrary a) => Arbitrary (Small a) where
-    arbitrary = Small <$> smallArbitrary
+    arbitrary = Small <$> (sized $ \n -> resize (smallish n) arbitrary)
+      where
+        smallish = round . (sqrt :: Double -> Double) . fromIntegral . abs
     shrink = map Small . shrink . fromSmall
 
-infix 4 =^=, =?=
+infix 4 =^=, =?=, =??=
 
 -- | Compares heterogeneous values
 class Eq' f g where
@@ -85,6 +83,50 @@ instance (Eq' a1 b1, Eq' a2 b2, Eq' a3 b3) => Eq' (a1, a2, a3) (b1, b2, b3)
 -- | Compares functions taking one scalar
 (=?=) :: Eq' a b => (t -> a) -> (t -> b) -> k -> t -> Bool
 f =?= g = const $ \t -> f t =^= g t
+
+-- | Compares functions taking two scalars
+(=??=) :: Eq' a b => (t -> s -> a) -> (t -> s -> b) -> k -> t -> s -> Bool
+f =??= g = const $ \t s -> f t s =^= g t s
+
+infix 4 =*=, =?*=, =*==
+
+-- | Types 'f' and 'g' have same behavior and common represenation 'r'.
+data SameAs f g r = SameAs {
+    toF   :: r -> f
+  , fromF :: f -> r
+  , toG   :: r -> g
+  , fromG :: g -> r
+  }
+
+-- | Compares two functions taking one container
+(=*=) :: (Eq' a b) => (f -> a) -> (g -> b)
+      -> SameAs f g r -> r -> Bool
+(f =*= g) sa i = f (toF sa i) =^= g (toG sa i)
+
+-- | Compares two functions taking one scalar and one container
+(=?*=) :: (Eq' a b) => (t -> f -> a) -> (t -> g -> b)
+       -> SameAs f g r -> r -> t -> Bool
+(f =?*= g) sa i t = (f t =*= g t) sa i
+
+-- | Compares functions taking two scalars and one container
+(=??*=) :: (Eq' a b) => (t -> s -> f -> a) -> (t -> s -> g -> b)
+        -> SameAs f g r -> r -> t -> s -> Bool
+(f =??*= g) sa i t s = (f t s =*= g t s) sa i
+
+-- | Compares two functions taking two containers
+(=**=) :: (Eq' a b) => (f -> f -> a) -> (g -> g -> b)
+       -> SameAs f g r -> r -> r -> Bool
+(f =**= g) sa i = (f (toF sa i) =*= g (toG sa i)) sa
+
+-- | Compares two functions taking one container with preprocessing
+(=*==) :: (Eq' f g) => (z -> f) -> (z -> g) -> (p -> z)
+       -> SameAs f g r -> p -> Bool
+(f =*== g) p _ i = f i' =^= g i'
+  where i' = p i
+
+-- | Input litst is non-empty
+notEmpty :: (SameAs c1 c2 [i] -> [i] -> Bool) -> SameAs c1 c2 [i] -> [i] -> Bool
+notEmpty f t items = null items || f t items
 
 -- Handy functions for fiddling with from ghci.
 

--- a/tests/Properties/Common.hs
+++ b/tests/Properties/Common.hs
@@ -2,13 +2,10 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Properties.Common
     (
-      V
-    , Small(..)
-    , unsquare
-    , smallArbitrary
+      Small(..)
     , qc
     , Eq'(..)
-    , SameAs (..)
+    , SameAs(..)
     , (=?=)
     , (=??=)
     , (=*=)
@@ -20,14 +17,10 @@ module Properties.Common
   ) where
 
 import Control.Applicative ((<$>))
-import Data.CritBit.Map.Lazy (CritBitKey, CritBit)
-import Data.Word (Word8)
 import Test.QuickCheck (Arbitrary(..), Args(..), quickCheckWith, stdArgs)
-import Test.QuickCheck.Gen (Gen, resize, sized)
-import Test.QuickCheck.Property (Property, Testable, forAll)
+import Test.QuickCheck.Gen (resize, sized)
+import Test.QuickCheck.Property (Testable)
 import qualified Data.ByteString.Char8 as B
-import qualified Data.CritBit.Map.Lazy as C
-import qualified Data.CritBit.Set as CS
 import qualified Data.Text as T
 
 instance Arbitrary B.ByteString where
@@ -37,27 +30,6 @@ instance Arbitrary B.ByteString where
 instance Arbitrary T.Text where
     arbitrary = T.pack <$> arbitrary
     shrink    = map T.pack . shrink . T.unpack
-
-type V = Word8
-
-instance (CritBitKey k, Arbitrary k, Arbitrary v) =>
-  Arbitrary (CritBit k v) where
-    arbitrary = C.fromList <$> arbitrary
-    shrink = map C.fromList . shrink . C.toList
-
-instance (CritBitKey k, Arbitrary k) =>
-  Arbitrary (CS.Set k) where
-    arbitrary = CS.fromList <$> arbitrary
-    shrink = map CS.fromList . shrink . CS.toList
-
--- For tests that have O(n^2) running times or input sizes, resize
--- their inputs to the square root of the originals.
-unsquare :: (Arbitrary a, Show a, Testable b) => (a -> b) -> Property
-unsquare = forAll smallArbitrary
-
-smallArbitrary :: (Arbitrary a, Show a) => Gen a
-smallArbitrary = sized $ \n -> resize (smallish n) arbitrary
-  where smallish = round . (sqrt :: Double -> Double) . fromIntegral . abs
 
 newtype Small a = Small { fromSmall :: a }
     deriving (Eq, Ord, Show)

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -9,13 +9,11 @@ import Data.Foldable (foldMap)
 import Data.Function (on)
 import Data.List (unfoldr, sort, nubBy)
 import Data.Map (Map)
-import Data.Monoid (Monoid, Sum(..))
-import Data.String (IsString)
+import Data.Monoid (Sum(..))
 import Data.Word (Word8)
 import Properties.Common
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.QuickCheck (Arbitrary)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.CritBit.Map.Lazy as C
 import qualified Data.CritBit.Set as CSet
@@ -50,7 +48,7 @@ vvfm = kvvfm ("" :: T.Text)
 vfm :: V -> Maybe V
 vfm = kvfm ("" :: T.Text)
 
-propertiesFor :: (Arbitrary k, CritBitKey k, Ord k, IsString k, Monoid k, Show k) => k -> [Test]
+propertiesFor :: Props k
 propertiesFor w = concat [[]
   -- ** Lists
   , prop sa "t_fromList" $

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -3,7 +3,6 @@ module Properties.Map
     where
 
 import Control.Arrow (second, (***))
-import Data.ByteString (ByteString)
 import Data.CritBit.Map.Lazy (CritBitKey, CritBit, byteCount)
 import Data.Foldable (foldMap)
 import Data.Function (on)
@@ -11,7 +10,6 @@ import Data.List (unfoldr, sort, nubBy)
 import Data.Map (Map)
 import Data.Monoid (Monoid,Sum(..),mappend)
 import Data.String (IsString)
-import Data.Text (Text)
 import Data.Word (Word8)
 import Properties.Common
 import Test.Framework (Test, testGroup)
@@ -624,16 +622,18 @@ propertiesFor t = [
   , testProperty "t_lookupLE" $ t_lookupLE t
 #endif
   , testProperty "t_delete_present" $ t_delete_present t
-  , testProperty "t_adjust_present" $ t_updateWithKey_present t
-  , testProperty "t_adjust_missing" $ t_updateWithKey_missing t
-  , testProperty "t_adjustWithKey_present" $ t_updateWithKey_present t
-  , testProperty "t_adjustWithKey_missing" $ t_updateWithKey_missing t
+  , testProperty "t_adjust_general" $ t_adjust_general t
+  , testProperty "t_adjust_present" $ t_adjust_present t
+  , testProperty "t_adjust_missing" $ t_adjust_missing t
+  , testProperty "t_adjustWithKey_general" $ t_adjustWithKey_general t
+  , testProperty "t_adjustWithKey_present" $ t_adjustWithKey_present t
+  , testProperty "t_adjustWithKey_missing" $ t_adjustWithKey_missing t
   , testProperty "t_updateWithKey_present" $ t_updateWithKey_present t
   , testProperty "t_updateWithKey_missing" $ t_updateWithKey_missing t
   , testProperty "t_update_present" $ t_update_present t
   , testProperty "t_update_missing" $ t_update_missing t
-  , testProperty "t_updateLookupWithKey_present" $ t_updateWithKey_present t
-  , testProperty "t_updateLookupWithKey_missing" $ t_updateWithKey_missing t
+  , testProperty "t_updateLookupWithKey_present" $ t_updateLookupWithKey_present t
+  , testProperty "t_updateLookupWithKey_missing" $ t_updateLookupWithKey_missing t
   , testProperty "t_mapMaybe" $ t_mapMaybe t
   , testProperty "t_mapMaybeWithKey" $ t_mapMaybeWithKey t
   , testProperty "t_mapEither" $ t_mapEither t
@@ -665,8 +665,8 @@ propertiesFor t = [
   , testProperty "t_mapKeys" $ t_mapKeys t
   , testProperty "t_mapKeysWith" $ t_mapKeysWith t
   , testProperty "t_mapKeysMonotonic" $ t_mapKeysMonotonic t
-  , testProperty "t_mapAccumWithKey"$ t_mapAccumWithKey t
-  , testProperty "t_mapAccumRWithKey"$ t_mapAccumRWithKey t
+  , testProperty "t_mapAccumWithKey" $ t_mapAccumWithKey t
+  , testProperty "t_mapAccumRWithKey" $ t_mapAccumRWithKey t
   , testProperty "t_toAscList" $ t_toAscList t
   , testProperty "t_toDescList" $ t_toDescList t
   , testProperty "t_fromAscList" $ t_fromAscList t
@@ -677,11 +677,12 @@ propertiesFor t = [
   , testProperty "t_insertWithKey_missing" $ t_insertWithKey_missing t
   , testProperty "t_insertLookupWithKey" $ t_insertLookupWithKey t
   , testProperty "t_filter" $ t_filter t
+  , testProperty "t_split_general" $ t_split_general t
   , testProperty "t_split_present" $ t_split_present t
   , testProperty "t_split_missing" $ t_split_missing t
-  , testProperty "t_splitLookup_present" $ t_split_present t
-  , testProperty "t_splitLookup_missing" $ t_split_missing t
-  , testProperty "t_isSubmapOf_ambiguous" $ t_isSubmapOfBy_ambiguous t
+  , testProperty "t_splitLookup_present" $ t_splitLookup_present t
+  , testProperty "t_splitLookup_missing" $ t_splitLookup_missing t
+  , testProperty "t_isSubmap_ambiguous" $ t_isSubmap_ambiguous t
   , testProperty "t_isSubmapOfBy_true" $ t_isSubmapOfBy_true t
   , testProperty "t_isSubmapOfBy_ambiguous" $ t_isSubmapOfBy_ambiguous t
   , testProperty "t_isProperSubmapOf_ambiguous" $

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -133,25 +133,13 @@ naiveUpdateLookupWithKey g k m =
       Nothing -> (Just v, C.delete k m)
     Nothing -> (Nothing, m)
 
-t_updateLookupWithKey_general :: (CritBitKey k)
-                              => (k -> V -> CritBit k V -> CritBit k V)
-                              -> k -> V -> CB k -> Bool
-t_updateLookupWithKey_general h k0 v0 (CB m0) =
-    C.updateLookupWithKey f k0 m1 == naiveUpdateLookupWithKey f k0 m1
+t_updateLookupWithKey :: (CritBitKey k, Ord k) => k -> KV k -> k -> Bool
+t_updateLookupWithKey = C.updateLookupWithKey f =??= Map.updateLookupWithKey f
   where
-    m1 = h k0 v0 m0
     f k x
       | even (fromIntegral x :: Int) =
         Just (x + fromIntegral (C.byteCount k))
       | otherwise = Nothing
-
-t_updateLookupWithKey_present :: (CritBitKey k) => k -> V -> CB k -> Bool
-t_updateLookupWithKey_present =
-  t_updateLookupWithKey_general C.insert
-
-t_updateLookupWithKey_missing :: (CritBitKey k) => k -> V -> CB k -> Bool
-t_updateLookupWithKey_missing =
-  t_updateLookupWithKey_general (\k _v m -> C.delete k m)
 
 t_update_general :: (CritBitKey k)
                  => (k -> V -> CritBit k V -> CritBit k V)
@@ -613,9 +601,8 @@ propertiesFor t = [
   , testProperty "t_updateWithKey_missing" $ t_updateWithKey_missing t
   , testProperty "t_update_present" $ t_update_present t
   , testProperty "t_update_missing" $ t_update_missing t
-  , testProperty "t_updateLookupWithKey_present" $ t_updateLookupWithKey_present t
-  , testProperty "t_updateLookupWithKey_missing" $ t_updateLookupWithKey_missing t
-  , testProperty "t_mapMaybe" $ t_mapMaybe t
+  ] ++ presentMissingProperty "t_updateLookupWithKey" t_updateLookupWithKey t ++ [
+    testProperty "t_mapMaybe" $ t_mapMaybe t
   , testProperty "t_mapMaybeWithKey" $ t_mapMaybeWithKey t
   , testProperty "t_mapEither" $ t_mapEither t
   , testProperty "t_mapEitherWithKey" $ t_mapEitherWithKey t

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -63,21 +63,17 @@ t_lookup :: WithKeyProp
 t_lookup = C.lookup =??= Map.lookup
 
 #if MIN_VERSION_containers(0,5,0)
-t_lookupGT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
-t_lookupGT _ k (KV kvs) =
-    C.lookupGT k (C.fromList kvs) == Map.lookupGT k (Map.fromList kvs)
+t_lookupGT :: WithKeyProp
+t_lookupGT = C.lookupGT =??= Map.lookupGT
 
-t_lookupGE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
-t_lookupGE _ k (KV kvs) =
-    C.lookupGE k (C.fromList kvs) == Map.lookupGE k (Map.fromList kvs)
+t_lookupGE :: WithKeyProp
+t_lookupGE = C.lookupGE =??= Map.lookupGE
 
-t_lookupLT :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
-t_lookupLT _ k (KV kvs) =
-    C.lookupLT k (C.fromList kvs) == Map.lookupLT k (Map.fromList kvs)
+t_lookupLT :: WithKeyProp
+t_lookupLT = C.lookupLT =??= Map.lookupLT
 
-t_lookupLE :: (Ord k, CritBitKey k) => k -> k -> KV k -> Bool
-t_lookupLE _ k (KV kvs) =
-    C.lookupLE k (C.fromList kvs) == Map.lookupLE k (Map.fromList kvs)
+t_lookupLE :: WithKeyProp
+t_lookupLE = C.lookupLE =??= Map.lookupLE
 #endif
 
 -- Test that the behaviour of a CritBit function is the same as that
@@ -90,15 +86,8 @@ isoWith :: (CritBitKey k, Ord k, Eq a) =>
 isoWith f g critbitf mapf _ (KV kvs) =
     (f . critbitf . C.fromList) kvs == (g . mapf . Map.fromList) kvs
 
--- Test that the behaviour of a CritBit function is the same as that
--- of its counterpart Map function.
-(===) :: (CritBitKey k, Ord k, Eq v) =>
-         (CritBit k V -> CritBit k v) -> (Map k V -> Map k v)
-      -> k -> KV k -> Bool
-(===) = isoWith C.toList Map.toList
-
 t_fromList_toList :: CBProp
-t_fromList_toList = id === id
+t_fromList_toList = id =?= id
 
 t_fromList_size :: CBProp
 t_fromList_size = isoWith C.size Map.size id id
@@ -129,11 +118,11 @@ t_delete :: WithKeyProp
 t_delete = C.delete =??= Map.delete
 
 t_adjust :: WithKeyProp
-t_adjust k kvs k0 = (C.adjust (+3) k0 === Map.adjust (+3) k0) k kvs
+t_adjust k kvs k0 = (C.adjust (+3) k0 =?= Map.adjust (+3) k0) k kvs
 
 t_adjustWithKey :: WithKeyProp
 t_adjustWithKey k kvs k0 =
-    (C.adjustWithKey f k0 === Map.adjustWithKey f k0) k kvs
+    (C.adjustWithKey f k0 =?= Map.adjustWithKey f k0) k kvs
   where f k v = v + fromIntegral (C.byteCount k)
 
 t_updateLookupWithKey :: WithKeyProp
@@ -160,12 +149,12 @@ t_updateWithKey = C.updateWithKey f =??= Map.updateWithKey f
       | otherwise = Nothing
 
 t_mapMaybe :: CBProp
-t_mapMaybe = C.mapMaybe f === Map.mapMaybe f
+t_mapMaybe = C.mapMaybe f =?= Map.mapMaybe f
   where
     f x = if even x then Just (2 * x) else Nothing
 
 t_mapMaybeWithKey :: CBProp
-t_mapMaybeWithKey = C.mapMaybeWithKey f === Map.mapMaybeWithKey f
+t_mapMaybeWithKey = C.mapMaybeWithKey f =?= Map.mapMaybeWithKey f
   where
     f k x
       | even (fromIntegral x :: Int) =
@@ -191,18 +180,18 @@ t_mapEitherWithKey =
 
 t_unionL :: WithMapProp
 t_unionL k (KV kvs) =
-    (C.unionL (C.fromList kvs) === Map.union (Map.fromList kvs)) k
+    (C.unionL (C.fromList kvs) =?= Map.union (Map.fromList kvs)) k
 
 t_unionR :: WithMapProp
 t_unionR k (KV kvs) =
-    (C.unionR (C.fromList kvs) === flip Map.union (Map.fromList kvs)) k
+    (C.unionR (C.fromList kvs) =?= flip Map.union (Map.fromList kvs)) k
 
 t_unionWith :: WithMapProp
-t_unionWith k (KV kvs) = (C.unionWith (-) (C.fromList kvs) ===
+t_unionWith k (KV kvs) = (C.unionWith (-) (C.fromList kvs) =?=
                           Map.unionWith (-) (Map.fromList kvs)) k
 
 t_unionWithKey :: WithMapProp
-t_unionWithKey k (KV kvs) = (C.unionWithKey f (C.fromList kvs) ===
+t_unionWithKey k (KV kvs) = (C.unionWithKey f (C.fromList kvs) =?=
                              Map.unionWithKey f (Map.fromList kvs)) k
   where
     f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
@@ -222,12 +211,12 @@ t_unionsWith _ (Small kvs0) =
     kvs = map fromKV kvs0
 
 t_difference :: WithMapProp
-t_difference k (KV kvs) = (C.difference (C.fromList kvs) ===
+t_difference k (KV kvs) = (C.difference (C.fromList kvs) =?=
     Map.difference (Map.fromList kvs)) k
 
 t_differenceWith :: WithMapProp
 t_differenceWith k (KV kvs) =
-    (C.differenceWith f (C.fromList kvs) ===
+    (C.differenceWith f (C.fromList kvs) =?=
         Map.differenceWith f (Map.fromList kvs)) k
   where
     f v1 v2 = if v1 `mod` 4 == 0
@@ -236,7 +225,7 @@ t_differenceWith k (KV kvs) =
 
 t_differenceWithKey :: WithMapProp
 t_differenceWithKey k (KV kvs) =
-    (C.differenceWithKey f (C.fromList kvs) ===
+    (C.differenceWithKey f (C.fromList kvs) =?=
         Map.differenceWithKey f (Map.fromList kvs)) k
   where
     f key v1 v2 = if C.byteCount key == 2
@@ -244,17 +233,17 @@ t_differenceWithKey k (KV kvs) =
                   else Just (fromIntegral (C.byteCount key) + v1 - v2)
 
 t_intersection :: WithMapProp
-t_intersection k (KV kvs) = (C.intersection (C.fromList kvs) ===
+t_intersection k (KV kvs) = (C.intersection (C.fromList kvs) =?=
     Map.intersection (Map.fromList kvs)) k
 
 t_intersectionWith :: WithMapProp
 t_intersectionWith k (KV kvs) =
-    (C.intersectionWith (-) (C.fromList kvs) ===
+    (C.intersectionWith (-) (C.fromList kvs) =?=
         Map.intersectionWith (-) (Map.fromList kvs)) k
 
 t_intersectionWithKey :: WithMapProp
 t_intersectionWithKey k (KV kvs) =
-    (C.intersectionWithKey f (C.fromList kvs) ===
+    (C.intersectionWithKey f (C.fromList kvs) =?=
         Map.intersectionWithKey f (Map.fromList kvs)) k
   where
     f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
@@ -288,12 +277,12 @@ t_keysSet = isoWith CSet.toList Set.toList C.keysSet Map.keysSet
 
 #if MIN_VERSION_containers(0,5,0)
 t_fromSet :: CBProp
-t_fromSet = (C.fromSet f . C.keysSet) === (Map.fromSet f . Map.keysSet)
+t_fromSet = (C.fromSet f . C.keysSet) =?= (Map.fromSet f . Map.keysSet)
   where f = length . show
 #endif
 
 t_map :: CBProp
-t_map = C.map (+3) === Map.map (+3)
+t_map = C.map (+3) =?= Map.map (+3)
 
 type M m a k v w = ((a -> k -> v -> (a, w)) -> a -> m k v -> (a, m k w))
 
@@ -308,17 +297,17 @@ prepends :: (CritBitKey k, Ord k, IsString k, Monoid k) => k -> k
 prepends = mappend "test"
 
 t_mapKeys :: CBProp
-t_mapKeys = C.mapKeys prepends === Map.mapKeys prepends
+t_mapKeys = C.mapKeys prepends =?= Map.mapKeys prepends
 
 t_mapKeysWith :: (CritBitKey k, Ord k, IsString k, Monoid k)
               => k -> KV k -> Bool
 t_mapKeysWith =
-  C.mapKeysWith (+) prepends === Map.mapKeysWith (+) prepends
+  C.mapKeysWith (+) prepends =?= Map.mapKeysWith (+) prepends
 
 t_mapKeysMonotonic :: (CritBitKey k, Ord k, IsString k, Monoid k)
                    => k -> KV k -> Bool
 t_mapKeysMonotonic =
-  C.mapKeysMonotonic prepends === Map.mapKeysMonotonic prepends
+  C.mapKeysMonotonic prepends =?= Map.mapKeysMonotonic prepends
 
 t_mapAccumRWithKey :: CBProp
 t_mapAccumRWithKey = mapAccumWithKey C.mapAccumRWithKey Map.mapAccumRWithKey
@@ -333,34 +322,34 @@ t_toDescList :: CBProp
 t_toDescList = isoWith C.toDescList Map.toDescList id id
 
 -- Check that 'toList's are equal, with input preprocessing
-(====) :: (CritBitKey k, Ord k) =>
+(=?==) :: (CritBitKey k, Ord k) =>
           ([(k, V)] -> CritBit k V) -> ([(k, V)] -> Map k V)
        -> ([(k, V)] -> [(k, V)]) -> KV k -> Bool
-(====) f g p (KV kvs) = C.toList (f kvs') == Map.toList (g kvs')
+(=?==) f g p (KV kvs) = C.toList (f kvs') == Map.toList (g kvs')
   where
     kvs' = p kvs
 
 t_fromAscList :: CBProp
-t_fromAscList _ = (C.fromAscList ==== Map.fromAscList) sort
+t_fromAscList _ = (C.fromAscList =?== Map.fromAscList) sort
 
 t_fromAscListWith :: CBProp
 t_fromAscListWith _ =
-    (C.fromAscListWith (+) ==== Map.fromAscListWith (+)) sort
+    (C.fromAscListWith (+) =?== Map.fromAscListWith (+)) sort
 
 t_fromAscListWithKey :: CBProp
 t_fromAscListWithKey _ =
-    (C.fromAscListWithKey f ==== Map.fromAscListWithKey f) sort
+    (C.fromAscListWithKey f =?== Map.fromAscListWithKey f) sort
   where
     f k v1 v2 = fromIntegral (C.byteCount k) + v1 + 2 * v2
 
 t_fromDistinctAscList :: (CritBitKey k, Ord k) => k -> k -> V -> KV k -> Bool
 t_fromDistinctAscList _ k v =
-    ((( C.insert k v) .   C.fromDistinctAscList) ====
+    ((( C.insert k v) .   C.fromDistinctAscList) =?==
     ((Map.insert k v) . Map.fromDistinctAscList))
     (nubBy ((==) `on` fst) . sort)
 
 t_filter :: CBProp
-t_filter = C.filter p === Map.filter p
+t_filter = C.filter p =?= Map.filter p
   where p = (> (maxBound - minBound) `div` 2)
 
 t_split :: WithKeyProp
@@ -410,10 +399,10 @@ t_findMax k w@(KV kvs) =
   null kvs || isoWith id id C.findMax Map.findMax k w
 
 t_deleteMin :: CBProp
-t_deleteMin = C.deleteMin === Map.deleteMin
+t_deleteMin = C.deleteMin =?= Map.deleteMin
 
 t_deleteMax :: CBProp
-t_deleteMax = C.deleteMax === Map.deleteMax
+t_deleteMax = C.deleteMax =?= Map.deleteMax
 
 deleteFindAll :: (m -> Bool) -> (m -> (a, m)) -> m -> [a]
 deleteFindAll isEmpty deleteFind m0 = unfoldr maybeDeleteFind m0
@@ -458,11 +447,11 @@ updateFun _ v
 
 t_updateMinWithKey :: CBProp
 t_updateMinWithKey =
-    C.updateMinWithKey updateFun === Map.updateMinWithKey updateFun
+    C.updateMinWithKey updateFun =?= Map.updateMinWithKey updateFun
 
 t_updateMaxWithKey :: CBProp
 t_updateMaxWithKey =
-    C.updateMaxWithKey updateFun === Map.updateMaxWithKey updateFun
+    C.updateMaxWithKey updateFun =?= Map.updateMaxWithKey updateFun
 
 t_insert :: WithKeyValueProp
 t_insert = C.insert =???= Map.insert
@@ -488,7 +477,7 @@ t_foldMap :: CBProp
 t_foldMap = isoWith (foldMap Sum) (foldMap Sum) id id
 
 t_mapWithKey :: CBProp
-t_mapWithKey = C.mapWithKey f === Map.mapWithKey f
+t_mapWithKey = C.mapWithKey f =?= Map.mapWithKey f
   where f _ = show . (+3)
 
 #if MIN_VERSION_containers(0,5,0)
@@ -503,7 +492,7 @@ t_traverseWithKey _ (KV kvs) = mappedC == mappedM
 
 alter :: (CritBitKey k, Ord k) =>
          (Maybe Word8 -> Maybe Word8) -> k -> KV k -> Bool
-alter f k = (C.alter f k === Map.alter f k) k
+alter f k = (C.alter f k =?= Map.alter f k) k
 
 t_alter :: CBProp
 t_alter = alter f
@@ -540,10 +529,10 @@ propertiesFor t = [
   , testProperty "t_null" $ t_null t
   , testProperty "t_size" $ t_size t
 #if MIN_VERSION_containers(0,5,0)
-  , testProperty "t_lookupGT" $ t_lookupGT t
-  , testProperty "t_lookupGE" $ t_lookupGE t
-  , testProperty "t_lookupLT" $ t_lookupLT t
-  , testProperty "t_lookupLE" $ t_lookupLE t
+  ] ++ presentMissingProperty "t_lookupGT" t_lookupGT t ++ [
+  ] ++ presentMissingProperty "t_lookupGE" t_lookupGE t ++ [
+  ] ++ presentMissingProperty "t_lookupLT" t_lookupLT t ++ [
+  ] ++ presentMissingProperty "t_lookupLE" t_lookupLE t ++ [
 #endif
   ] ++ presentMissingProperty "t_lookup" t_lookup t ++ [
   ] ++ presentMissingProperty "t_delete" t_delete t ++ [

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -86,33 +86,15 @@ isoWith :: (CritBitKey k, Ord k, Eq a) =>
 isoWith f g critbitf mapf _ (KV kvs) =
     (f . critbitf . C.fromList) kvs == (g . mapf . Map.fromList) kvs
 
-t_fromList_toList :: CBProp
-t_fromList_toList = id =?= id
+t_fromList :: CBProp
+t_fromList _ (KV kvs) = C.fromList kvs =*= Map.fromList kvs
 
-t_fromList_size :: CBProp
-t_fromList_size = isoWith C.size Map.size id id
+t_fromListWith :: CBProp
+t_fromListWith _ (KV kvs) = C.fromListWith (+) kvs =*= Map.fromListWith (+) kvs
 
-t_fromListWith_toList :: CBProp
-t_fromListWith_toList _ (KV kvs) =
-    Map.toList (Map.fromListWith (+) kvsDup) == C.toList (C.fromListWith (+) kvsDup)
-    where kvsDup = concatMap (replicate 2) kvs
-
-t_fromListWith_size :: CBProp
-t_fromListWith_size _ (KV kvs) =
-    Map.size (Map.fromListWith (+) kvsDup) == C.size (C.fromListWith (+) kvsDup)
-    where kvsDup = concatMap (replicate 2) kvs
-
-t_fromListWithKey_toList :: CBProp
-t_fromListWithKey_toList _ (KV kvs) =
-    Map.toList (Map.fromListWithKey f kvsDup) == C.toList (C.fromListWithKey f kvsDup)
-    where kvsDup = concatMap (replicate 2) kvs
-          f key a1 a2 = toEnum (byteCount key) + a1 + a2
-
-t_fromListWithKey_size :: CBProp
-t_fromListWithKey_size _ (KV kvs) =
-    Map.size (Map.fromListWithKey f kvsDup) == C.size (C.fromListWithKey f kvsDup)
-    where kvsDup = concatMap (replicate 2) kvs
-          f key a1 a2 = toEnum (byteCount key) + a1 + a2
+t_fromListWithKey :: CBProp
+t_fromListWithKey _ (KV kvs) = C.fromListWithKey f kvs =*= Map.fromListWithKey f kvs
+  where f key a1 a2 = toEnum (byteCount key) * 2 + a1 - a2
 
 t_delete :: WithKeyProp
 t_delete = C.delete =??= Map.delete
@@ -520,12 +502,9 @@ t_partition _ (KV kvs) = partCrit == partMap
 
 propertiesFor :: (Arbitrary k, CritBitKey k, Ord k, IsString k, Monoid k, Show k) => k -> [Test]
 propertiesFor t = [
-    testProperty "t_fromList_toList" $ t_fromList_toList t
-  , testProperty "t_fromList_size" $ t_fromList_size t
-  , testProperty "t_fromListWith_toList" $ t_fromListWith_toList t
-  , testProperty "t_fromListWith_size" $ t_fromListWith_size t
-  , testProperty "t_fromListWithKey_toList" $ t_fromListWithKey_toList t
-  , testProperty "t_fromListWithKey_size" $ t_fromListWithKey_size t
+    testProperty "t_fromList" $ t_fromList t
+  , testProperty "t_fromListWith" $ t_fromListWith t
+  , testProperty "t_fromListWithKey" $ t_fromListWithKey t
   , testProperty "t_null" $ t_null t
   , testProperty "t_size" $ t_size t
 #if MIN_VERSION_containers(0,5,0)

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -10,13 +10,13 @@ import Data.Foldable (foldMap)
 import Data.Function (on)
 import Data.List (unfoldr, sort, nubBy)
 import Data.Map (Map)
-import Data.Monoid (Monoid,Sum(..),mappend)
+import Data.Monoid (Monoid, Sum(..))
 import Data.String (IsString)
 import Data.Word (Word8)
 import Properties.Common
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.QuickCheck (Arbitrary(..))
+import Test.QuickCheck (Arbitrary)
 import Test.QuickCheck.Property (Testable)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.CritBit.Map.Lazy as C
@@ -218,9 +218,6 @@ t_fromSet = (C.fromSet f . C.keysSet) =*= (Map.fromSet f . Map.keysSet)
 
 t_map :: CBProp
 t_map = C.map (+3) =*= Map.map (+3)
-
-prepends :: (CritBitKey k, Ord k, IsString k, Monoid k) => k -> k
-prepends = mappend "test"
 
 t_mapKeys :: CBProp
 t_mapKeys = C.mapKeys prepends =*= Map.mapKeys prepends

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -161,20 +161,16 @@ t_mapEitherWithKey =
       | otherwise = Right (2 * x)
 
 t_unionL :: WithMapProp
-t_unionL k (KV kvs) =
-    (C.unionL (C.fromList kvs) =?= Map.union (Map.fromList kvs)) k
+t_unionL = C.unionL =**= Map.union
 
 t_unionR :: WithMapProp
-t_unionR k (KV kvs) =
-    (C.unionR (C.fromList kvs) =?= flip Map.union (Map.fromList kvs)) k
+t_unionR = C.unionR =**= flip Map.union
 
 t_unionWith :: WithMapProp
-t_unionWith k (KV kvs) = (C.unionWith (-) (C.fromList kvs) =?=
-                          Map.unionWith (-) (Map.fromList kvs)) k
+t_unionWith = C.unionWith (-) =**= Map.unionWith (-)
 
 t_unionWithKey :: WithMapProp
-t_unionWithKey k (KV kvs) = (C.unionWithKey f (C.fromList kvs) =?=
-                             Map.unionWithKey f (Map.fromList kvs)) k
+t_unionWithKey = C.unionWithKey f =**= Map.unionWithKey f
   where
     f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
 
@@ -193,40 +189,30 @@ t_unionsWith _ (Small kvs0) =
     kvs = map fromKV kvs0
 
 t_difference :: WithMapProp
-t_difference k (KV kvs) = (C.difference (C.fromList kvs) =?=
-    Map.difference (Map.fromList kvs)) k
+t_difference = C.difference =**= Map.difference
 
 t_differenceWith :: WithMapProp
-t_differenceWith k (KV kvs) =
-    (C.differenceWith f (C.fromList kvs) =?=
-        Map.differenceWith f (Map.fromList kvs)) k
+t_differenceWith = C.differenceWith f =**= Map.differenceWith f
   where
     f v1 v2 = if v1 `mod` 4 == 0
               then Nothing
               else Just (v1 - v2)
 
 t_differenceWithKey :: WithMapProp
-t_differenceWithKey k (KV kvs) =
-    (C.differenceWithKey f (C.fromList kvs) =?=
-        Map.differenceWithKey f (Map.fromList kvs)) k
+t_differenceWithKey = C.differenceWithKey f =**= Map.differenceWithKey f
   where
     f key v1 v2 = if C.byteCount key == 2
                   then Nothing
                   else Just (fromIntegral (C.byteCount key) + v1 - v2)
 
 t_intersection :: WithMapProp
-t_intersection k (KV kvs) = (C.intersection (C.fromList kvs) =?=
-    Map.intersection (Map.fromList kvs)) k
+t_intersection = C.intersection =**= Map.intersection
 
 t_intersectionWith :: WithMapProp
-t_intersectionWith k (KV kvs) =
-    (C.intersectionWith (-) (C.fromList kvs) =?=
-        Map.intersectionWith (-) (Map.fromList kvs)) k
+t_intersectionWith = C.intersectionWith (-) =**= Map.intersectionWith (-)
 
 t_intersectionWithKey :: WithMapProp
-t_intersectionWithKey k (KV kvs) =
-    (C.intersectionWithKey f (C.fromList kvs) =?=
-        Map.intersectionWithKey f (Map.fromList kvs)) k
+t_intersectionWithKey = C.intersectionWithKey f =**= Map.intersectionWithKey f
   where
     f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
 
@@ -635,6 +621,13 @@ f =??= g = \k kvs t -> (f t =?= g t) k kvs
         => (t -> s -> CritBit k V -> a) -> (t -> s -> Map k V -> b)
         -> k -> KV k -> t -> s -> Bool
 f =???= g = \k kvs t s -> (f t s =?= g t s) k kvs
+
+-- | Compares (map -> map -> result) functions
+(=**=) :: (Ord k, CritBitKey k, Eq' a b)
+        => (CritBit k V -> CritBit k V -> a) -> (Map k V -> Map k V -> b)
+        -> k -> KV k -> KV k -> Bool
+f =**= g = \k kvs (KV kvs2)
+           -> (f (C.fromList kvs2) =?= g (Map.fromList kvs2)) k kvs
 
 -- Handy functions for fiddling with from ghci.
 

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -162,19 +162,17 @@ t_unionWithKey = C.unionWithKey f =**= Map.unionWithKey f
   where
     f key v1 v2 = fromIntegral (C.byteCount key) + v1 - v2
 
+cbs :: CritBitKey k => Small [KV k] -> [CritBit k V]
+cbs = map C.fromList . map fromKV . fromSmall
+
+maps :: Ord k => Small [KV k] -> [Map k V]
+maps = map Map.fromList . map fromKV . fromSmall
+
 t_unions :: (CritBitKey k, Ord k) => k -> Small [KV k] -> Bool
-t_unions _ (Small kvs0) =
-    Map.toList (Map.unions (map Map.fromList kvs)) ==
-    C.toList (C.unions (map C.fromList kvs))
-  where
-    kvs = map fromKV kvs0
+t_unions = C.unions . cbs =?= Map.unions . maps
 
 t_unionsWith :: (CritBitKey k, Ord k) => k -> Small [KV k] -> Bool
-t_unionsWith _ (Small kvs0) =
-    Map.toList (Map.unionsWith (-) (map Map.fromList kvs)) ==
-    C.toList (C.unionsWith (-) (map C.fromList kvs))
-  where
-    kvs = map fromKV kvs0
+t_unionsWith = C.unionsWith (-) . cbs =?= Map.unionsWith (-) . maps
 
 t_difference :: WithMapProp
 t_difference = C.difference =**= Map.difference

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -56,6 +56,9 @@ presentMissingProperty name t w = [
 t_null :: CBProp
 t_null = C.null =?= Map.null
 
+t_size :: CBProp
+t_size = C.size =?= Map.size
+
 t_lookup :: WithKeyProp
 t_lookup = C.lookup =??= Map.lookup
 
@@ -535,6 +538,7 @@ propertiesFor t = [
   , testProperty "t_fromListWithKey_toList" $ t_fromListWithKey_toList t
   , testProperty "t_fromListWithKey_size" $ t_fromListWithKey_size t
   , testProperty "t_null" $ t_null t
+  , testProperty "t_size" $ t_size t
 #if MIN_VERSION_containers(0,5,0)
   , testProperty "t_lookupGT" $ t_lookupGT t
   , testProperty "t_lookupGE" $ t_lookupGE t

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -141,22 +141,12 @@ t_updateLookupWithKey = C.updateLookupWithKey f =??= Map.updateLookupWithKey f
         Just (x + fromIntegral (C.byteCount k))
       | otherwise = Nothing
 
-t_update_general :: (CritBitKey k)
-                 => (k -> V -> CritBit k V -> CritBit k V)
-                 -> k -> V -> CB k -> Bool
-t_update_general h k0 v0 (CB m0) = C.update f k0 m1 == naiveUpdate f k0 m1
+t_update :: (CritBitKey k, Ord k) => k -> KV k -> k -> Bool
+t_update = C.update f =??= Map.update f
   where
-    m1 = h k0 v0 m0
-    naiveUpdate g k = snd . naiveUpdateLookupWithKey (const g) k
     f x
       | even (fromIntegral x :: Int) = Just (x * 10)
       | otherwise                    = Nothing
-
-t_update_present :: (CritBitKey k) => k -> V -> CB k -> Bool
-t_update_present = t_update_general C.insert
-
-t_update_missing :: (CritBitKey k) => k -> V -> CB k -> Bool
-t_update_missing = t_update_general (\k _v m -> C.delete k m)
 
 t_updateWithKey_general :: (CritBitKey k)
                         => (k -> V -> CritBit k V -> CritBit k V)
@@ -599,8 +589,7 @@ propertiesFor t = [
   ] ++ presentMissingProperty "t_adjustWithKey" t_adjustWithKey t ++ [
     testProperty "t_updateWithKey_present" $ t_updateWithKey_present t
   , testProperty "t_updateWithKey_missing" $ t_updateWithKey_missing t
-  , testProperty "t_update_present" $ t_update_present t
-  , testProperty "t_update_missing" $ t_update_missing t
+  ] ++ presentMissingProperty "t_update" t_update t ++ [
   ] ++ presentMissingProperty "t_updateLookupWithKey" t_updateLookupWithKey t ++ [
     testProperty "t_mapMaybe" $ t_mapMaybe t
   , testProperty "t_mapMaybeWithKey" $ t_mapMaybeWithKey t

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -30,6 +30,7 @@ import qualified Data.Text as T
 import Data.Functor.Identity (Identity(..))
 #endif
 
+type V = Word8
 type KV k = [(k, V)]
 
 type SA k = SameAs (CritBit k V) (Map k V) (KV k)
@@ -42,9 +43,6 @@ type WithKeyValueProp = (CritBitKey k, Ord k, Show k, IsString k, Monoid k)
                       => SA k -> KV k -> k -> V -> Bool
 type WithMapProp      = (CritBitKey k, Ord k, Show k, IsString k, Monoid k)
                       => SA k -> KV k -> KV k -> Bool
-
-newtype CB k = CB (CritBit k V)
-    deriving (Show, Eq, Arbitrary)
 
 presentMissingProperty :: (Eq k, Arbitrary k, Show k, IsString k, Testable t)
                        => String -> (SA k -> KV k -> k -> t) -> SA k -> [Test]

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -1,10 +1,9 @@
-{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, TypeFamilies, OverloadedStrings #-}
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, OverloadedStrings #-}
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, Rank2Types #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Properties.Map
     where
 
-import Control.Arrow ((***))
 import Data.CritBit.Map.Lazy (CritBitKey, CritBit, byteCount)
 import Data.Foldable (foldMap)
 import Data.Function (on)
@@ -17,7 +16,6 @@ import Properties.Common
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck (Arbitrary)
-import Test.QuickCheck.Property (Testable)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.CritBit.Map.Lazy as C
 import qualified Data.CritBit.Set as CSet
@@ -31,30 +29,6 @@ import Data.Functor.Identity (Identity(..))
 #endif
 
 type V = Word8
-type KV k = [(k, V)]
-
-type SA k = SameAs (CritBit k V) (Map k V) (KV k)
-
-type CBProp           = (CritBitKey k, Ord k, Show k, IsString k, Monoid k)
-                      => SA k -> KV k -> Bool
-type WithKeyProp      = (CritBitKey k, Ord k, Show k, IsString k, Monoid k)
-                      => SA k -> KV k -> k -> Bool
-type WithKeyValueProp = (CritBitKey k, Ord k, Show k, IsString k, Monoid k)
-                      => SA k -> KV k -> k -> V -> Bool
-type WithMapProp      = (CritBitKey k, Ord k, Show k, IsString k, Monoid k)
-                      => SA k -> KV k -> KV k -> Bool
-
-presentMissingProperty :: (Eq k, Arbitrary k, Show k, IsString k, Testable t)
-                       => String -> (SA k -> KV k -> k -> t) -> SA k -> [Test]
-presentMissingProperty name t sa = [
-    testProperty (name ++ "_general") $ general
-  , testProperty (name ++ "_present") $ present
-  , testProperty (name ++ "_missing") $ missing
-  ]
-  where
-    general k   kvs = t sa kvs k
-    present k v kvs = t sa ((k, v):kvs) k
-    missing k   kvs = t sa (filter ((/= k) . fst) kvs) k
 
 -- * Common modifier functions
 
@@ -76,382 +50,272 @@ vvfm = kvvfm ("" :: T.Text)
 vfm :: V -> Maybe V
 vfm = kvfm ("" :: T.Text)
 
--- * Test properties
-
-t_null :: CBProp
-t_null = C.null =*= Map.null
-
-t_size :: CBProp
-t_size = C.size =*= Map.size
-
-t_lookup :: WithKeyProp
-t_lookup = C.lookup =?*= Map.lookup
-
-#if MIN_VERSION_containers(0,5,0)
-t_lookupGT :: WithKeyProp
-t_lookupGT = C.lookupGT =?*= Map.lookupGT
-
-t_lookupGE :: WithKeyProp
-t_lookupGE = C.lookupGE =?*= Map.lookupGE
-
-t_lookupLT :: WithKeyProp
-t_lookupLT = C.lookupLT =?*= Map.lookupLT
-
-t_lookupLE :: WithKeyProp
-t_lookupLE = C.lookupLE =?*= Map.lookupLE
-#endif
-
-t_fromList :: CBProp
-t_fromList = C.fromList =?= Map.fromList
-
-t_fromListWith :: CBProp
-t_fromListWith = C.fromListWith (-) =?= Map.fromListWith (-)
-
-t_fromListWithKey :: CBProp
-t_fromListWithKey = C.fromListWithKey kvvf =?= Map.fromListWithKey kvvf
-
-t_delete :: WithKeyProp
-t_delete = C.delete =?*= Map.delete
-
-t_adjust :: WithKeyProp
-t_adjust = C.adjust (+3) =?*= Map.adjust (+3)
-
-t_adjustWithKey :: WithKeyProp
-t_adjustWithKey = C.adjustWithKey kvf =?*= Map.adjustWithKey kvf
-
-t_updateLookupWithKey :: WithKeyProp
-t_updateLookupWithKey = C.updateLookupWithKey kvfm =?*=
-                      Map.updateLookupWithKey kvfm
-
-t_update :: WithKeyProp
-t_update = C.update vfm =?*= Map.update vfm
-
-t_updateWithKey :: WithKeyProp
-t_updateWithKey = C.updateWithKey kvfm =?*= Map.updateWithKey kvfm
-
-t_mapMaybe :: CBProp
-t_mapMaybe = C.mapMaybe vfm =*= Map.mapMaybe vfm
-
-t_mapMaybeWithKey :: CBProp
-t_mapMaybeWithKey = C.mapMaybeWithKey kvfm =*= Map.mapMaybeWithKey kvfm
-
-t_mapEither :: CBProp
-t_mapEither = (C.toList *** C.toList) . C.mapEither f =*=
-              (Map.toList *** Map.toList) . Map.mapEither f
-  where f x = if even x then Left (2 * x) else Right (3 * x)
-
-t_mapEitherWithKey :: CBProp
-t_mapEitherWithKey = (C.toList *** C.toList) . C.mapEitherWithKey f =*=
-                     (Map.toList *** Map.toList) . Map.mapEitherWithKey f
-  where f k x = if even x then Left (x + toEnum (C.byteCount k))
-                          else Right (2 * x)
-
-t_unionL :: WithMapProp
-t_unionL = C.unionL =**= Map.union
-
-t_unionR :: WithMapProp
-t_unionR = C.unionR =**= flip Map.union
-
-t_unionWith :: WithMapProp
-t_unionWith = C.unionWith (-) =**= Map.unionWith (-)
-
-t_unionWithKey :: WithMapProp
-t_unionWithKey = C.unionWithKey kvvf =**= Map.unionWithKey kvvf
-
-t_unions :: (CritBitKey k, Ord k) => SA k -> Small [KV k] -> Bool
-t_unions = (C.unions . map C.fromList =*==
-          Map.unions . map Map.fromList) fromSmall
-
-t_unionsWith :: (CritBitKey k, Ord k) => SA k -> Small [KV k] -> Bool
-t_unionsWith = (C.unionsWith (-) . map C.fromList =*==
-              Map.unionsWith (-) . map Map.fromList) fromSmall
-
-t_difference :: WithMapProp
-t_difference = C.difference =**= Map.difference
-
-t_differenceWith :: WithMapProp
-t_differenceWith = C.differenceWith vvfm =**= Map.differenceWith vvfm
-
-t_differenceWithKey :: WithMapProp
-t_differenceWithKey = C.differenceWithKey kvvfm =**= Map.differenceWithKey kvvfm
-
-t_intersection :: WithMapProp
-t_intersection = C.intersection =**= Map.intersection
-
-t_intersectionWith :: WithMapProp
-t_intersectionWith = C.intersectionWith (-) =**= Map.intersectionWith (-)
-
-t_intersectionWithKey :: WithMapProp
-t_intersectionWithKey = C.intersectionWithKey kvvf =**=
-                        Map.intersectionWithKey kvvf
-
-t_foldl :: CBProp
-t_foldl = C.foldl (-) 0 =*= Map.foldl (-) 0
-
-t_foldlWithKey :: CBProp
-t_foldlWithKey = C.foldlWithKey f ([], 0) =*= Map.foldlWithKey f ([], 0)
-  where
-    f (l,s) k v = (k:l,s+v)
-
-t_foldl' :: CBProp
-t_foldl' = C.foldl' (-) 0 =*= Map.foldl' (-) 0
-
-t_foldlWithKey' :: CBProp
-t_foldlWithKey' = C.foldlWithKey' f ([], 0) =*= Map.foldlWithKey' f ([], 0)
-  where
-    f (l,s) k v = (k:l,s+v)
-
-t_elems :: CBProp
-t_elems = C.elems =*= Map.elems
-
-t_keys :: CBProp
-t_keys = C.keys =*= Map.keys
-
-t_keysSet :: CBProp
-t_keysSet = CSet.toList . C.keysSet =*= Set.toList . Map.keysSet
-
-#if MIN_VERSION_containers(0,5,0)
-t_fromSet :: CBProp
-t_fromSet = (C.fromSet f . C.keysSet) =*= (Map.fromSet f . Map.keysSet)
-  where f = length . show
-#endif
-
-t_map :: CBProp
-t_map = C.map (+3) =*= Map.map (+3)
-
-t_mapKeys :: CBProp
-t_mapKeys = C.mapKeys prepends =*= Map.mapKeys prepends
-
-t_mapKeysWith :: CBProp
-t_mapKeysWith = C.mapKeysWith (+) prepends =*= Map.mapKeysWith (+) prepends
-
-t_mapKeysMonotonic :: CBProp
-t_mapKeysMonotonic =
-  C.mapKeysMonotonic prepends =*= Map.mapKeysMonotonic prepends
-
-t_mapAccumRWithKey :: CBProp
-t_mapAccumRWithKey = C.mapAccumRWithKey f 0 =*= Map.mapAccumRWithKey f 0
-  where f i _ v = (i + 1 :: Int, show $ v + 3)
-
-t_mapAccumWithKey :: CBProp
-t_mapAccumWithKey = C.mapAccumWithKey f 0 =*= Map.mapAccumWithKey f 0
-  where f i _ v = (i + 1 :: Int, show $ v + 3)
-
-t_toAscList :: CBProp
-t_toAscList = C.toAscList =*= Map.toAscList
-
-t_toDescList :: CBProp
-t_toDescList = C.toDescList =*= Map.toDescList
-
-t_fromAscList :: CBProp
-t_fromAscList = (C.fromAscList =*== Map.fromAscList) sort
-
-t_fromAscListWith :: CBProp
-t_fromAscListWith =
-    (C.fromAscListWith (+) =*== Map.fromAscListWith (+)) sort
-
-t_fromAscListWithKey :: CBProp
-t_fromAscListWithKey =
-    (C.fromAscListWithKey kvvf =*== Map.fromAscListWithKey kvvf) sort
-
-t_fromDistinctAscList :: CBProp
-t_fromDistinctAscList = (C.fromDistinctAscList =*== Map.fromDistinctAscList) p
-  where p = nubBy ((==) `on` fst) . sort
-
-t_filter :: CBProp
-t_filter = C.filter p =*= Map.filter p
-  where p = (> (maxBound - minBound) `div` 2)
-
-t_split :: WithKeyProp
-t_split = C.split =?*= Map.split
-
-t_splitLookup :: WithKeyProp
-t_splitLookup = C.splitLookup =?*= Map.splitLookup
-
-t_isSubmapOf :: WithMapProp
-t_isSubmapOf = C.isSubmapOf =**= Map.isSubmapOf
-
-t_isSubmapOfBy :: WithMapProp
-t_isSubmapOfBy = C.isSubmapOfBy (<=) =**= Map.isSubmapOfBy (<=)
-
-t_isProperSubmapOf :: WithMapProp
-t_isProperSubmapOf = C.isProperSubmapOf =**= Map.isProperSubmapOf
-
-t_isProperSubmapOfBy :: WithMapProp
-t_isProperSubmapOfBy = C.isProperSubmapOfBy (<=) =**= Map.isProperSubmapOfBy (<=)
-
-t_findMin :: CBProp
-t_findMin = notEmpty (C.findMin =*= Map.findMin)
-
-t_findMax :: CBProp
-t_findMax = notEmpty (C.findMax =*= Map.findMax)
-
-t_deleteMin :: CBProp
-t_deleteMin = C.deleteMin =*= Map.deleteMin
-
-t_deleteMax :: CBProp
-t_deleteMax = C.deleteMax =*= Map.deleteMax
-
-t_deleteFindMin :: CBProp
-t_deleteFindMin = notEmpty (C.deleteFindMin =*= Map.deleteFindMin)
-
-t_deleteFindMax :: CBProp
-t_deleteFindMax = notEmpty (C.deleteFindMax =*= Map.deleteFindMax)
-
-t_minView :: CBProp
-t_minView = unfoldr C.minView =*= unfoldr Map.minView
-
-t_maxView :: CBProp
-t_maxView = unfoldr C.maxView =*= unfoldr Map.maxView
-
-t_minViewWithKey :: CBProp
-t_minViewWithKey = unfoldr C.minViewWithKey =*= unfoldr Map.minViewWithKey
-
-t_maxViewWithKey :: CBProp
-t_maxViewWithKey = unfoldr C.maxViewWithKey =*= unfoldr Map.maxViewWithKey
-
-t_updateMinWithKey :: CBProp
-t_updateMinWithKey = C.updateMinWithKey kvfm =*= Map.updateMinWithKey kvfm
-
-t_updateMaxWithKey :: CBProp
-t_updateMaxWithKey = C.updateMaxWithKey kvfm =*= Map.updateMaxWithKey kvfm
-
-t_insert :: WithKeyValueProp
-t_insert = C.insert =??*= Map.insert
-
-t_insertWith :: WithKeyValueProp
-t_insertWith = C.insertWith (-) =??*= Map.insertWith (-)
-
-t_insertWithKey :: WithKeyValueProp
-t_insertWithKey = C.insertWithKey kvvf =??*= Map.insertWithKey kvvf
-
-t_insertLookupWithKey :: WithKeyValueProp
-t_insertLookupWithKey = C.insertLookupWithKey kvvf =??*=
-                        Map.insertLookupWithKey kvvf
-
-t_foldMap :: CBProp
-t_foldMap = foldMap Sum =*= foldMap Sum
-
-t_mapWithKey :: CBProp
-t_mapWithKey = C.mapWithKey kvf =*= Map.mapWithKey kvf
-
-#if MIN_VERSION_containers(0,5,0)
-t_traverseWithKey :: CBProp
-t_traverseWithKey = runIdentity . C.traverseWithKey f =*=
-                    runIdentity . Map.traverseWithKey f
-  where f _   = Identity . show . (+3)
-#endif
-
-t_alter :: WithKeyProp
-t_alter = C.alter f =?*= Map.alter f
-  where f = Just . maybe 1 (+1)
-
-t_alter_delete :: WithKeyProp
-t_alter_delete = C.alter (const Nothing) =?*= Map.alter (const Nothing)
-
-t_partitionWithKey :: CBProp
-t_partitionWithKey = C.partitionWithKey p =*= Map.partitionWithKey p
-  where p k v = odd $ C.byteCount k + fromIntegral v
-
-t_partition :: CBProp
-t_partition = C.partition odd =*= Map.partition odd
-
 propertiesFor :: (Arbitrary k, CritBitKey k, Ord k, IsString k, Monoid k, Show k) => k -> [Test]
-propertiesFor w = [
-    testProperty "t_fromList" $ t_fromList t
-  , testProperty "t_fromListWith" $ t_fromListWith t
-  , testProperty "t_fromListWithKey" $ t_fromListWithKey t
-  , testProperty "t_null" $ t_null t
-  , testProperty "t_size" $ t_size t
+propertiesFor w = concat [[]
+  -- ** Lists
+  , prop sa "t_fromList" $
+        (C.fromList =*== Map.fromList) id
+  , prop sa "t_fromListWith" $
+        (C.fromListWith (-) =*== Map.fromListWith (-)) id
+  , prop sa "t_fromListWithKey" $
+        (C.fromListWithKey kvvf =*== Map.fromListWithKey kvvf) id
+
+    -- * Query
+  , prop sa "t_null" $
+        C.null =*= Map.null
+  , prop sa "t_size" $
+        C.size =*= Map.size
+  , prop sa "t_member" $
+        C.member =?*= Map.member
+  , prop sa "t_member" $
+        C.notMember =?*= Map.notMember
+  , prop sa "t_lookup" $
+        C.lookup =?*= Map.lookup
+  , prop sa "t_findWithDefault" $
+        C.findWithDefault =??*= Map.findWithDefault
+
 #if MIN_VERSION_containers(0,5,0)
-  ] ++ presentMissingProperty "t_lookupGT" t_lookupGT t ++ [
-  ] ++ presentMissingProperty "t_lookupGE" t_lookupGE t ++ [
-  ] ++ presentMissingProperty "t_lookupLT" t_lookupLT t ++ [
-  ] ++ presentMissingProperty "t_lookupLE" t_lookupLE t ++ [
+  , prop sa "t_lookupGT" $
+        C.lookupGT =?*= Map.lookupGT
+  , prop sa "t_lookupGE" $
+        C.lookupGE =?*= Map.lookupGE
+  , prop sa "t_lookupLT" $
+        C.lookupLT =?*= Map.lookupLT
+  , prop sa "t_lookupLE" $
+        C.lookupLE =?*= Map.lookupLE
 #endif
-  ] ++ presentMissingProperty "t_lookup" t_lookup t ++ [
-  ] ++ presentMissingProperty "t_delete" t_delete t ++ [
-  ] ++ presentMissingProperty "t_adjust" t_adjust t ++ [
-  ] ++ presentMissingProperty "t_adjustWithKey" t_adjustWithKey t ++ [
-  ] ++ presentMissingProperty "t_update" t_update t ++ [
-  ] ++ presentMissingProperty "t_updateWithKey" t_updateWithKey t ++ [
-  ] ++ presentMissingProperty "t_updateLookupWithKey" t_updateLookupWithKey t ++ [
-    testProperty "t_mapMaybe" $ t_mapMaybe t
-  , testProperty "t_mapMaybeWithKey" $ t_mapMaybeWithKey t
-  , testProperty "t_mapEither" $ t_mapEither t
-  , testProperty "t_mapEitherWithKey" $ t_mapEitherWithKey t
-  , testProperty "t_unionL" $ t_unionL t
-  , testProperty "t_unionR" $ t_unionR t
-  , testProperty "t_unionWith" $ t_unionWith t
-  , testProperty "t_unionWithKey" $ t_unionWithKey t
-  , testProperty "t_unions" $ t_unions t
-  , testProperty "t_unionsWith" $ t_unionsWith t
-  , testProperty "t_difference" $ t_difference t
-  , testProperty "t_differenceWith" $ t_differenceWith t
-  , testProperty "t_differenceWithKey" $ t_differenceWithKey t
-  , testProperty "t_intersection" $ t_intersection t
-  , testProperty "t_intersectionWith" $ t_intersectionWith t
-  , testProperty "t_intersectionWithKey" $ t_intersectionWithKey t
-  , testProperty "t_foldl" $ t_foldl t
-  , testProperty "t_foldlWithKey" $ t_foldlWithKey t
-  , testProperty "t_foldl'" $ t_foldl' t
-  , testProperty "t_foldlWithKey'" $ t_foldlWithKey' t
-  , testProperty "t_elems" $ t_elems t
-  , testProperty "t_keys" $ t_keys t
-  , testProperty "t_keysSet" $ t_keysSet t
+
+  -- * Insertion
+  , pmprop sa "t_insert" $
+        C.insert =??*= Map.insert
+  , pmprop sa "t_insertWith" $
+        C.insertWith (-) =??*= Map.insertWith (-)
+  , pmprop sa "t_insertWithKey" $
+        C.insertWithKey kvvf =??*= Map.insertWithKey kvvf
+  , pmprop sa "t_insertLookupWithKey" $
+        C.insertLookupWithKey kvvf =??*= Map.insertLookupWithKey kvvf
+
+  -- * Deletion
+  , pmprop sa "t_delete" $
+        C.delete =?*= Map.delete
+  , pmprop sa "t_adjust" $
+        C.adjust (+3) =?*= Map.adjust (+3)
+  , pmprop sa "t_adjustWithKey" $
+        C.adjustWithKey kvf =?*= Map.adjustWithKey kvf
+  , pmprop sa "t_update" $
+        C.update vfm =?*= Map.update vfm
+  , pmprop sa "t_updateWithKey" $
+        C.updateWithKey kvfm =?*= Map.updateWithKey kvfm
+  , pmprop sa "t_updateLookupWithKey" $
+        C.updateLookupWithKey kvfm =?*= Map.updateLookupWithKey kvfm
+  , prop sa "t_alter" $
+        let f = Just . maybe 1 (+1)
+        in C.alter f =?*= Map.alter f
+  , prop sa "t_alter_delete" $
+        C.alter (const Nothing) =?*= Map.alter (const Nothing)
+
+  -- * Combination
+  -- ** Union
+  , prop sa "t_union" $
+        C.union =**= Map.union
+  , prop sa "t_unionWith" $
+        C.unionWith (-) =**= Map.unionWith (-)
+  , prop sa "t_unionWithKey" $
+        C.unionWithKey kvvf =**= Map.unionWithKey kvvf
+  , prop sa "t_unions" $
+        (  C.unions . map   C.fromList =*==
+         Map.unions . map Map.fromList) fromSmall
+  , prop sa "t_unionsWith" $
+        (  C.unionsWith (-) . map   C.fromList =*==
+         Map.unionsWith (-) . map Map.fromList) fromSmall
+  , prop sa "t_unionL" $
+        C.unionL =**= Map.union
+  , prop sa "t_unionR" $
+        C.unionR =**= flip Map.union
+
+  -- ** Difference
+  , prop sa "t_difference" $
+        C.difference =**= Map.difference
+  , prop sa "t_differenceWith" $
+        C.differenceWith vvfm =**= Map.differenceWith vvfm
+  , prop sa "t_differenceWithKey" $
+        C.differenceWithKey kvvfm =**= Map.differenceWithKey kvvfm
+
+  -- ** Intersection
+  , prop sa "t_intersection" $
+        C.intersection =**= Map.intersection
+  , prop sa "t_intersectionWith" $
+        C.intersectionWith (-) =**= Map.intersectionWith (-)
+  , prop sa "t_intersectionWithKey" $
+        C.intersectionWithKey kvvf =**= Map.intersectionWithKey kvvf
+
+  -- * Traversal
+  -- ** Map
+  , prop sa "t_map" $
+        C.map (+3) =*= Map.map (+3)
+  , prop sa "t_mapWithKey" $
+        C.mapWithKey kvf =*= Map.mapWithKey kvf
 #if MIN_VERSION_containers(0,5,0)
-  , testProperty "t_fromSet" $ t_fromSet t
+  , prop sa "t_traverseWithKey" $
+      let f _ = Identity . show . (+3)
+      in runIdentity . C.traverseWithKey f =*= runIdentity . Map.traverseWithKey f
 #endif
-  , testProperty "t_map" $ t_map t
-  , testProperty "t_mapWithKey" $ t_mapWithKey t
-  , testProperty "t_mapKeys" $ t_mapKeys t
-  , testProperty "t_mapKeysWith" $ t_mapKeysWith t
-  , testProperty "t_mapKeysMonotonic" $ t_mapKeysMonotonic t
-  , testProperty "t_mapAccumWithKey" $ t_mapAccumWithKey t
-  , testProperty "t_mapAccumRWithKey" $ t_mapAccumRWithKey t
-  , testProperty "t_toAscList" $ t_toAscList t
-  , testProperty "t_toDescList" $ t_toDescList t
-  , testProperty "t_fromAscList" $ t_fromAscList t
-  , testProperty "t_fromAscListWith" $ t_fromAscListWith t
-  , testProperty "t_fromAscListWithKey" $ t_fromAscListWithKey t
-  , testProperty "t_fromDistinctAscList" $ t_fromDistinctAscList t
-  , testProperty "t_insertLookupWithKey" $ t_insertLookupWithKey t
-  , testProperty "t_filter" $ t_filter t
-  ] ++ presentMissingProperty "t_split" t_split t ++ [
-  ] ++ presentMissingProperty "t_splitLookup" t_splitLookup t ++ [
-    testProperty "t_isSubmapOf" $ t_isSubmapOf t
-  , testProperty "t_isSubmapOfBy" $ t_isSubmapOfBy t
-  , testProperty "t_isProperSubmapOf" $ t_isProperSubmapOf t
-  , testProperty "t_isProperSubmapOfBy" $ t_isProperSubmapOfBy t
-  , testProperty "t_findMin" $ t_findMin t
-  , testProperty "t_findMax" $ t_findMax t
-  , testProperty "t_deleteMin" $ t_deleteMin t
-  , testProperty "t_deleteMax" $ t_deleteMax t
-  , testProperty "t_deleteFindMin" $ t_deleteFindMin t
-  , testProperty "t_deleteFindMax" $ t_deleteFindMax t
-  , testProperty "t_minView" $ t_minView t
-  , testProperty "t_maxView" $ t_maxView t
-  , testProperty "t_minViewWithKey" $ t_minViewWithKey t
-  , testProperty "t_maxViewWithKey" $ t_maxViewWithKey t
-  , testProperty "t_updateMinWithKey" $ t_updateMinWithKey t
-  , testProperty "t_updateMaxWithKey" $ t_updateMaxWithKey t
-  ] ++ presentMissingProperty "t_insert" t_insert t ++ [
-  ] ++ presentMissingProperty "t_insertWith" t_insertWith t ++ [
-  ] ++ presentMissingProperty "t_insertWithKey" t_insertWithKey t ++ [
-    testProperty "t_insertLookupWithKey" $ t_insertLookupWithKey t
+  , prop sa "t_mapAccum" $
+        let f i v = (i + 1 :: Int, show $ v + 3)
+        in C.mapAccum f 0 =*= Map.mapAccum f 0
+  , prop sa "t_mapAccumWithKey" $
+        let f i k v = (i + byteCount k, show $ v + 3)
+        in C.mapAccumWithKey f 0 =*= Map.mapAccumWithKey f 0
+  , prop sa "t_mapAccumRWithKey" $
+        let f i k v = (i + byteCount k, show $ v + 3)
+        in C.mapAccumRWithKey f 0 =*= Map.mapAccumRWithKey f 0
+  , prop sa "t_mapKeys" $
+        C.mapKeys kf =*= Map.mapKeys kf
+  , prop sa "t_mapKeysWith" $
+        C.mapKeysWith (+) kf =*= Map.mapKeysWith (+) kf
+  , prop sa "t_mapKeysMonotonic" $
+        C.mapKeysMonotonic prepends =*= Map.mapKeysMonotonic prepends
+
+  -- * Folds
+  , prop sa "t_foldl" $
+        C.foldl (-) 0 =*= Map.foldl (-) 0
+  , prop sa "t_foldlWithKey" $
+        let f i k v = i * 37 + (byteCount k) * 17 + fromIntegral v
+        in C.foldlWithKey f 0 =*= Map.foldlWithKey f 0
+  , prop sa "t_foldr" $
+        C.foldr (-) 0 =*= Map.foldr (-) 0
+  , prop sa "t_foldrWithKey" $
+        let f k v i = i * 37 + (byteCount k) * 17 + fromIntegral v
+        in C.foldrWithKey f 0 =*= Map.foldrWithKey f 0
+
+  -- ** Strict folds
+  , prop sa "t_foldl'" $
+        C.foldl' (-) 0 =*= Map.foldl' (-) 0
+  , prop sa "t_foldlWithKey'" $
+        let f i k v = i * 37 + (byteCount k) * 17 + fromIntegral v
+        in C.foldlWithKey' f 0 =*= Map.foldlWithKey' f 0
+  , prop sa "t_foldr'" $
+        C.foldr' (-) 0 =*= Map.foldr' (-) 0
+  , prop sa "t_foldrWithKey'" $
+        let f k v i = i * 37 + (byteCount k) * 17 + fromIntegral v
+        in C.foldrWithKey' f 0 =*= Map.foldrWithKey' f 0
+
+  -- * Conversion
+  , prop sa "t_elems" $
+        C.elems =*= Map.elems
+  , prop sa "t_keys" $
+        C.keys =*= Map.keys
+  , prop sa "assocs" $
+        C.assocs =*= Map.assocs
+  , prop sa "t_keysSet" $
+        CSet.toList . C.keysSet =*= Set.toList . Map.keysSet
 #if MIN_VERSION_containers(0,5,0)
-  , testProperty "t_traverseWithKey" $ t_traverseWithKey t
+  , prop sa "t_fromSet" $
+        let f = length . show
+        in C.fromSet f . C.keysSet =*= Map.fromSet f . Map.keysSet
 #endif
-  , testProperty "t_foldMap" $ t_foldMap t
-  , testProperty "t_alter" $ t_alter t
-  , testProperty "t_alter_delete" $ t_alter_delete t
-  , testProperty "t_partition" $ t_partition t
-  , testProperty "t_partitionWithKey" $ t_partitionWithKey t
+
+  -- ** Ordered lists
+  , prop sa "t_toAscList" $
+        C.toAscList =*= Map.toAscList
+  , prop sa "t_toDescList" $
+        C.toDescList =*= Map.toDescList
+  , prop sa "t_fromAscList" $
+        (C.fromAscList =*== Map.fromAscList) sort
+  , prop sa "t_fromAscListWith" $
+        (C.fromAscListWith (+) =*== Map.fromAscListWith (+)) sort
+  , prop sa "t_fromAscListWithKey" $
+        (C.fromAscListWithKey kvvf =*== Map.fromAscListWithKey kvvf) sort
+  , prop sa "t_fromDistinctAscList" $
+        let p = nubBy ((==) `on` fst) . sort
+        in (C.fromDistinctAscList =*== Map.fromDistinctAscList) p
+
+  -- * Filter
+  , prop sa "t_filter" $
+        C.filter odd =*= Map.filter odd
+  , prop sa "t_filterWithKey" $
+        let p k v = odd $ kvf k v
+        in C.filterWithKey p =*= Map.filterWithKey p
+  , prop sa "t_partition" $ C.partition odd =*= Map.partition odd
+  , prop sa "t_partitionWithKey" $
+       let p k v = odd $ kvf k v
+       in C.partitionWithKey p =*= Map.partitionWithKey p
+
+  , prop sa "t_mapMaybe" $
+        C.mapMaybe vfm =*= Map.mapMaybe vfm
+  , prop sa "t_mapMaybeWithKey" $
+        C.mapMaybeWithKey kvfm =*= Map.mapMaybeWithKey kvfm
+  , prop sa "t_mapEither" $
+        let f v = if even v then Left (2 * v) else Right (3 * v)
+        in C.mapEither f =*= Map.mapEither f
+  , prop sa "t_mapEitherWithKey" $
+        let f k v = if even v then Left (kvf k v) else Right (3 * v)
+        in C.mapEitherWithKey f =*= Map.mapEitherWithKey f
+
+  , pmprop sa "t_split" $
+        C.split =?*= Map.split
+  , pmprop sa "t_splitLookup" $
+        C.splitLookup =?*= Map.splitLookup
+
+  -- * Submap
+  , prop sa "t_isSubmapOf" $
+        C.isSubmapOf =**= Map.isSubmapOf
+  , prop sa "t_isSubmapOfBy" $
+        C.isSubmapOfBy (<=) =**= Map.isSubmapOfBy (<=)
+  , prop sa "t_isProperSubmapOf" $
+        C.isProperSubmapOf =**= Map.isProperSubmapOf
+  , prop sa "t_isProperSubmapOfBy" $
+        C.isProperSubmapOfBy (<=) =**= Map.isProperSubmapOfBy (<=)
+
+  -- * Min\/Max
+  , prop sa "t_findMin" $ notEmpty $
+        C.findMin =*= Map.findMin
+  , prop sa "t_findMax" $ notEmpty $
+        C.findMax =*= Map.findMax
+  , prop sa "t_deleteMin" $ notEmpty $
+        C.deleteMin =*= Map.deleteMin
+  , prop sa "t_deleteMax" $ notEmpty $
+        C.deleteMax =*= Map.deleteMax
+  , prop sa "t_deleteFindMin" $ notEmpty $
+        C.deleteFindMin =*= Map.deleteFindMin
+  , prop sa "t_deleteFindMax" $ notEmpty $
+        C.deleteFindMax =*= Map.deleteFindMax
+  , prop sa "t_updateMin" $
+        C.updateMinWithKey kvfm =*= Map.updateMinWithKey kvfm
+  , prop sa "t_updateMax" $
+        C.updateMaxWithKey kvfm =*= Map.updateMaxWithKey kvfm
+  , prop sa "t_updateMinWithKey" $
+        C.updateMinWithKey kvfm =*= Map.updateMinWithKey kvfm
+  , prop sa "t_updateMaxWithKey" $
+        C.updateMaxWithKey kvfm =*= Map.updateMaxWithKey kvfm
+  , prop sa "t_minView" $
+        unfoldr C.minView =*= unfoldr Map.minView
+  , prop sa "t_maxView" $
+        unfoldr C.maxView =*= unfoldr Map.maxView
+  , prop sa "t_minViewWithKey" $
+        unfoldr C.minViewWithKey =*= unfoldr Map.minViewWithKey
+  , prop sa "t_maxViewWithKey" $
+        unfoldr C.maxViewWithKey =*= unfoldr Map.maxViewWithKey
+
+  , prop sa "t_foldMap" $
+        foldMap Sum =*= foldMap Sum
   ]
   where
-    t = sameAs w
+    prop sa' name q = [testProperty name $ q sa']
+    pmprop sa' name t = [
+       testProperty (name ++ "_general") $ general
+     , testProperty (name ++ "_present") $ present
+     , testProperty (name ++ "_missing") $ missing
+     ]
+     where
+       general k   kvs = t sa' kvs k
+       present k v kvs = t sa' ((k, v):kvs) k
+       missing k   kvs = t sa' (filter ((/= k) . fst) kvs) k
 
-    sameAs :: (CritBitKey k, Ord k) => k -> SA k
+    sa = sameAs w
+
+    sameAs :: (CritBitKey k, Ord k)
+           => k -> SameAs (CritBit k V) (Map k V) [(k, V)]
     sameAs _ = SameAs C.fromList C.toList Map.fromList Map.toList
 
 properties :: [Test]

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -54,7 +54,7 @@ presentMissingProperty name t w = [
     missing k   (KV kvs) = t w (KV (filter ((/= k) . fst) kvs)) k
 
 t_null :: CBProp
-t_null _ (KV kvs) = C.null (C.fromList kvs) == null kvs
+t_null = C.null =?= Map.null
 
 t_lookup :: WithKeyProp
 t_lookup = C.lookup =??= Map.lookup

--- a/tests/Properties/Map.hs
+++ b/tests/Properties/Map.hs
@@ -3,7 +3,7 @@
 module Properties.Map
     where
 
-import Control.Arrow (second, (***))
+import Control.Arrow ((***))
 import Data.CritBit.Map.Lazy (CritBitKey, CritBit, byteCount)
 import Data.Foldable (foldMap)
 import Data.Function (on)
@@ -236,15 +236,6 @@ t_fromSet = (C.fromSet f . C.keysSet) =*= (Map.fromSet f . Map.keysSet)
 t_map :: CBProp
 t_map = C.map (+3) =*= Map.map (+3)
 
-type M m a k v w = ((a -> k -> v -> (a, w)) -> a -> m k v -> (a, m k w))
-
-mapAccumWithKey :: (w ~ String, v ~ V, a ~ Int, Ord k, CritBitKey k) =>
-                   M CritBit a k v w -> M Map a k v w -> k -> KV k -> Bool
-mapAccumWithKey critbitF mapF _ (KV kvs) = mappedC == mappedM
-  where fun i _ v = (i + 1, show $ v + 3)
-        mappedC = second C.toList . critbitF fun 0 $ (C.fromList kvs)
-        mappedM = second Map.toList . mapF fun 0 $ (Map.fromList kvs)
-
 prepends :: (CritBitKey k, Ord k, IsString k, Monoid k) => k -> k
 prepends = mappend "test"
 
@@ -259,10 +250,12 @@ t_mapKeysMonotonic =
   C.mapKeysMonotonic prepends =*= Map.mapKeysMonotonic prepends
 
 t_mapAccumRWithKey :: CBProp
-t_mapAccumRWithKey = mapAccumWithKey C.mapAccumRWithKey Map.mapAccumRWithKey
+t_mapAccumRWithKey = C.mapAccumRWithKey f 0 =*= Map.mapAccumRWithKey f 0
+  where f i _ v = (i + 1 :: Int, show $ v + 3)
 
 t_mapAccumWithKey :: CBProp
-t_mapAccumWithKey = mapAccumWithKey C.mapAccumWithKey Map.mapAccumWithKey
+t_mapAccumWithKey = C.mapAccumWithKey f 0 =*= Map.mapAccumWithKey f 0
+  where f i _ v = (i + 1 :: Int, show $ v + 3)
 
 t_toAscList :: CBProp
 t_toAscList = C.toAscList =*= Map.toAscList

--- a/tests/Properties/Set.hs
+++ b/tests/Properties/Set.hs
@@ -8,12 +8,10 @@ import Data.CritBit.Map.Lazy (CritBitKey, byteCount)
 import qualified Data.CritBit.Set as C
 import qualified Data.Set as S
 
-import Test.QuickCheck (Arbitrary)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Data.String (IsString)
 import Data.List (unfoldr, sort, nub)
-import Data.Monoid (Monoid)
 
 import qualified Data.Text as T
 import qualified Data.ByteString.Char8 as B
@@ -24,7 +22,7 @@ kp = even . byteCount
 kii :: (CritBitKey k, Show k, IsString k) => k -> Int -> Int
 kii k v = byteCount k * 13 + v
 
-propertiesFor :: (Arbitrary k, CritBitKey k, Eq k, Ord k, Show k, IsString k, Monoid k) => k -> [Test]
+propertiesFor :: Props k
 propertiesFor t = concat [[]
   -- * Operators
   , prop "t_diff" $ (C.\\) =**= (S.\\)

--- a/tests/Properties/Set.hs
+++ b/tests/Properties/Set.hs
@@ -11,7 +11,7 @@ import qualified Data.Set as S
 import Test.QuickCheck (Arbitrary)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Data.String (IsString, fromString)
+import Data.String (IsString)
 import Data.List (unfoldr, sort, nub)
 import Data.Monoid (Monoid)
 
@@ -20,9 +20,6 @@ import qualified Data.ByteString.Char8 as B
 
 kp :: (CritBitKey k) => k -> Bool
 kp = even . byteCount
-
-kf :: (CritBitKey k, Show k, IsString k) => k -> k
-kf k = fromString $ show (byteCount k) ++ show k
 
 kii :: (CritBitKey k, Show k, IsString k) => k -> Int -> Int
 kii k v = byteCount k * 13 + v

--- a/tests/Properties/Set.hs
+++ b/tests/Properties/Set.hs
@@ -1,280 +1,114 @@
-{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, OverloadedStrings, TypeFamilies #-}
+﻿{-# LANGUAGE CPP, MultiParamTypeClasses, FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Properties.Set
     where
 
-import Control.Arrow ((***))
-import Data.ByteString (ByteString)
-import Data.CritBit.Map.Lazy (CritBitKey, byteCount)
-import Data.Foldable (foldMap)
-import Data.List (unfoldr, sort, nub)
-import Data.Monoid (Sum(..), Monoid, (<>))
-import Data.String (IsString)
-import Data.Text (Text)
 import Properties.Common
+import Data.CritBit.Map.Lazy (CritBitKey, byteCount)
+import qualified Data.CritBit.Set as C
+import qualified Data.Set as S
+
+import Test.QuickCheck (Arbitrary(..))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.QuickCheck (Arbitrary(..))
-import qualified Data.ByteString.Char8 as B
-import qualified Data.CritBit.Set as CS
-import qualified Data.Set as Set
+import Data.String (IsString, fromString)
+import Data.List (unfoldr, sort, nub)
+
 import qualified Data.Text as T
+import qualified Data.ByteString.Char8 as B
 
-t_null :: (CritBitKey k) => k -> [k] -> Bool
-t_null _ ks = CS.null (CS.fromList ks) == null ks
+kp :: (CritBitKey k) => k -> Bool
+kp = even . byteCount
 
-t_member_present :: (CritBitKey k) => k -> CS.Set k -> Bool
-t_member_present k = CS.member k . CS.insert k
+kf :: (CritBitKey k, Show k, IsString k) => k -> k
+kf k = fromString $ show (byteCount k) ++ show k
 
-t_member_missing :: (CritBitKey k) => k -> CS.Set k -> Bool
-t_member_missing k = not . CS.member k . CS.delete k
+kii :: (CritBitKey k, Show k, IsString k) => k -> Int -> Int
+kii k v = byteCount k * 13 + v
 
+fmono :: (CritBitKey k, Show k, IsString k) => k -> k
+fmono k = fromString $ "test" ++ show k
+
+propertiesFor :: (Arbitrary k, CritBitKey k, Eq k, Ord k, Show k, IsString k)
+              => k -> [Test]
+propertiesFor t = concat [[]
+  -- * Operators
+  , prop "t_diff" $ (C.\\) =**= (S.\\)
+
+  -- * Query
+  , prop "t_null" $ C.null =*= S.null
+  , prop "t_size" $ C.size =*= S.size
+  , prop "t_member" $ C.member =?*= S.member
+  , prop "t_notMember" $ C.notMember =?*= S.notMember
 #if MIN_VERSION_containers(0,5,0)
-t_lookupGT :: (Ord k, CritBitKey k) => k -> k -> [k] -> Bool
-t_lookupGT _ k ks =
-    CS.lookupGT k (CS.fromList ks) == Set.lookupGT k (Set.fromList ks)
-
-t_lookupGE :: (Ord k, CritBitKey k) => k -> k -> [k] -> Bool
-t_lookupGE _ k ks =
-    CS.lookupGE k (CS.fromList ks) == Set.lookupGE k (Set.fromList ks)
-
-t_lookupLT :: (Ord k, CritBitKey k) => k -> k -> [k] -> Bool
-t_lookupLT _ k ks =
-    CS.lookupLT k (CS.fromList ks) == Set.lookupLT k (Set.fromList ks)
-
-t_lookupLE :: (Ord k, CritBitKey k) => k -> k -> [k] -> Bool
-t_lookupLE _ k ks =
-    CS.lookupLE k (CS.fromList ks) == Set.lookupLE k (Set.fromList ks)
+  , prop "t_lookupLT" $ C.lookupLT =?*= S.lookupLT
+  , prop "t_lookupGT" $ C.lookupGT =?*= S.lookupGT
+  , prop "t_lookupLE" $ C.lookupLE =?*= S.lookupLE
+  , prop "t_lookupGE" $ C.lookupGE =?*= S.lookupGE
 #endif
+  , prop "t_isSubsetOf" $ C.isSubsetOf =**= S.isSubsetOf
+  , prop "t_isProperSubsetOf" $ C.isProperSubsetOf =**= S.isProperSubsetOf
 
--- Test that the behaviour of a CritBit function is the same as that
--- of its counterpart Map function, under some mapping of their
--- results.
-isoWith :: (CritBitKey k, Ord k, Eq a) =>
-           (c -> a) -> (m -> a)
-        -> (CS.Set k -> c) -> (Set.Set k -> m)
-        -> k -> [k] -> Bool
-isoWith f g critbitf mapf _ ks =
-    (f . critbitf . CS.fromList) ks == (g . mapf . Set.fromList) ks
+  -- * Construction
+--  , prop "t_empty" $ C.empty =^= S.empty
+  , prop "t_singleton" $ notEmpty $ (C.singleton =*== S.singleton) head
+  , prop "t_insert" $ C.insert =?*= S.insert
+  , prop "t_delete" $ C.delete =?*= S.delete
 
--- Test that the behaviour of a CritBit function is the same as that
--- of its counterpart Map function.
-(===) :: (CritBitKey k, Ord k) =>
-         (CS.Set k -> CS.Set k) -> (Set.Set k -> Set.Set k)
-      -> k -> [k] -> Bool
-(===) = isoWith CS.toList Set.toList
+  -- * Combine
+  , prop "t_union" $ C.union =**= S.union
+  , prop "t_unions" $ (C.unions . map C.fromList =*==
+                         S.unions . map S.fromList) fromSmall
+  , prop "t_difference" $ C.difference =**= S.difference
+  , prop "t_intersection" $ C.intersection =**= S.intersection
 
-t_fromList_toList :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_fromList_toList = id === id
+  -- * Filter
+  , prop "t_filter" $ C.filter kp =*= S.filter kp
+  , prop "t_partition" $ C.partition kp =*= S.partition kp
+  , prop "t_split" $ C.split =?*= S.split
+  , prop "t_splitMember" $ C.splitMember =?*= S.splitMember
 
-t_fromList_size :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_fromList_size = isoWith CS.size Set.size id id
+  -- * Map
+  , prop "t_map" $ C.map kf =*= S.map kf
+  , prop "t_mapMonotonic" $ C.mapMonotonic fmono =*= S.mapMonotonic fmono
 
-t_delete_present :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_delete_present k ks =
-    CS.toList (CS.delete k c) == Set.toList (Set.delete k m)
-  where
-    c = CS.insert k $ CS.fromList ks
-    m = Set.insert k $ Set.fromList ks
+  -- * Folds
+  , prop "t_foldr" $ C.foldr kii 0 =*= S.foldr kii 0
+  , prop "t_foldl" $ C.foldl (flip kii) 0 =*= S.foldl (flip kii) 0
+  -- ** Strict folds
+  , prop "t_foldr'" $ C.foldr' kii 0 =*= S.foldr' kii 0
+  , prop "t_foldl'" $ C.foldl' (flip kii) 0 =*= S.foldl' (flip kii) 0
 
-t_unions :: (CritBitKey k, Ord k) => k -> Small [[k]] -> Bool
-t_unions _ (Small ks) =
-    Set.toList (Set.unions (map Set.fromList ks)) ==
-    CS.toList (CS.unions (map CS.fromList ks))
+  -- * Min\/Max
+  , prop "t_findMin" $ notEmpty $ C.findMin =*= S.findMin
+  , prop "t_findMax" $ notEmpty $ C.findMax =*= S.findMax
+  , prop "t_deleteMin" $ notEmpty $ C.deleteMin =*= S.deleteMin
+  , prop "t_deleteMax" $ notEmpty $ C.deleteMax =*= S.deleteMax
+  , prop "t_deleteFindMin" $ notEmpty $ C.deleteFindMin =*= S.deleteFindMin
+  , prop "t_deleteFindMax" $ notEmpty $ C.deleteFindMax =*= S.deleteFindMax
+  , prop "t_maxView" $ notEmpty $ unfoldr C.maxView =*= unfoldr S.maxView
+  , prop "t_minView" $ notEmpty $ unfoldr C.minView =*= unfoldr S.minView
 
-t_difference :: (CritBitKey k, Ord k) => k -> [k] -> [k] -> Bool
-t_difference k ks = (CS.difference (CS.fromList ks) ===
-    Set.difference (Set.fromList ks)) k
+  -- * Conversion
+  -- ** List
+  , prop "t_elems" $ C.elems =*= S.elems
+  , prop "t_toList" $ C.toList =*= S.toList
+  , prop "t_fromList" $ (C.fromList =*== S.fromList) id
 
-t_intersection :: (CritBitKey k, Ord k) => k -> [k] -> [k] -> Bool
-t_intersection k ks = (CS.intersection (CS.fromList ks) ===
-    Set.intersection (Set.fromList ks)) k
-
-t_foldl :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_foldl = isoWith id id (CS.foldl f 0) (Set.foldl f 0)
-  where f a b = a + byteCount b
-
-t_foldl' :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_foldl' = isoWith id id (CS.foldl' f 0) (Set.foldl' f 0)
-  where f a b = a + byteCount b
-
-t_elems :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_elems = isoWith id id CS.elems Set.elems
-
-t_map :: (CritBitKey k, Ord k, Monoid k, IsString k) => k -> [k] -> Bool
-t_map = CS.map (<>"a") === Set.map (<>"a")
-
-t_toAscList :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_toAscList = isoWith CS.toAscList Set.toAscList id id
-
+  -- ** Ordered list
+  , prop "t_toAscList" $ C.toAscList =*= S.toAscList
 #if MIN_VERSION_containers(0,5,0)
-t_toDescList :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_toDescList = isoWith CS.toDescList Set.toDescList id id
+  , prop "t_toDescList" $ C.toDescList =*= S.toDescList
 #endif
-
--- Check that 'toList's are equal, with input preprocessing
-(====) :: Eq a =>
-          (c -> CS.Set a) -> (c -> Set.Set a) -> (t -> c) -> t -> Bool
-(====) f g p ks = CS.toList (f ks') == Set.toList (g ks')
-  where
-    ks' = p ks
-
-t_fromAscList :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_fromAscList _ = (CS.fromAscList ==== Set.fromAscList) sort
-
-t_fromDistinctAscList :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_fromDistinctAscList k =
-    ((CS.insert k .   CS.fromDistinctAscList) ====
-    (Set.insert k . Set.fromDistinctAscList))
-    (nub . sort)
-
-t_filter :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_filter = CS.filter p === Set.filter p
-  where p = (> (maxBound - minBound) `div` 2) . byteCount
-
-t_split_general :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_split_general k = isoWith (CS.toList *** CS.toList) (Set.toList *** Set.toList)
-                            (CS.split k) (Set.split k) k
-
-t_split_present :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_split_present k ks = t_split_general k (k:ks)
-
-t_split_missing :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_split_missing k ks = t_split_general k (filter (/=k) ks)
-
-unpack3 :: (m -> a) -> (m, b, m) -> (a, b, a)
-unpack3 f (a, k, b) = (f a, k, f b)
-
-t_submap_general :: (CritBitKey k, Ord k) =>
-                    (CS.Set k -> CS.Set k -> Bool)
-                 -> (Set.Set k -> Set.Set k -> Bool)
-                 -> [k] -> [k] -> Bool
-t_submap_general cf mf ks1 ks2 =
-  cf (CS.fromList ks1) (CS.fromList ks2) ==
-  mf (Set.fromList ks1) (Set.fromList ks2)
-
-t_isSubset_ambiguous :: (CritBitKey k, Ord k) => k -> [k] -> [k] -> Bool
-t_isSubset_ambiguous _ ks1 ks2 =
-  t_submap_general CS.isSubsetOf Set.isSubsetOf ks1 ks2
-
-
-t_isProperSubsetOf_ambiguous :: (CritBitKey k, Ord k) =>
-                              k -> [k] -> [k] -> Bool
-t_isProperSubsetOf_ambiguous _ ks1 ks2 =
-  t_submap_general CS.isProperSubsetOf Set.isProperSubsetOf ks1 ks2
-
-t_findMin :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_findMin k w@ks =
-  null ks || isoWith id id CS.findMin Set.findMin k w
-
-t_findMax :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_findMax k w@ks =
-  null ks || isoWith id id CS.findMax Set.findMax k w
-
-t_deleteMin :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_deleteMin = CS.deleteMin === Set.deleteMin
-
-t_deleteMax :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_deleteMax = CS.deleteMax === Set.deleteMax
-
-deleteFindAll :: (m -> Bool) -> (m -> (a, m)) -> m -> [a]
-deleteFindAll isEmpty deleteFind m0 = unfoldr maybeDeleteFind m0
-  where maybeDeleteFind m
-          | isEmpty m = Nothing
-          | otherwise = Just . deleteFind $ m
-
-t_deleteFindMin :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_deleteFindMin _ ks =
-    deleteFindAll CS.null CS.deleteFindMin (CS.fromList ks) ==
-    deleteFindAll Set.null Set.deleteFindMin (Set.fromList ks)
-
-t_deleteFindMax :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_deleteFindMax _ ks =
-    deleteFindAll CS.null CS.deleteFindMax (CS.fromList ks) ==
-    deleteFindAll Set.null Set.deleteFindMax (Set.fromList ks)
-
-t_minView :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_minView _ ks =
-  unfoldr CS.minView (CS.fromList ks) ==
-  unfoldr Set.minView (Set.fromList ks)
-
-t_maxView :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_maxView _ ks =
-  unfoldr CS.maxView (CS.fromList ks) ==
-  unfoldr Set.maxView (Set.fromList ks)
-
-updateFun :: Integral v => k -> v -> Maybe v
-updateFun _ v
-  | v `rem` 2 == 0 = Nothing
-  | otherwise = Just (v + 1)
-
-t_insert_present :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_insert_present k =
-    ((CS.insert k . CS.insert k) === (Set.insert k . Set.insert k)) k
-
-t_insert_missing :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_insert_missing k ks = (CS.insert k === Set.insert k) k (filter (/=k) ks)
-
-t_foldMap :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_foldMap = isoWith (foldMap f) (foldMap f) id id
-  where f = Sum . byteCount
-
-t_partition :: (CritBitKey k, Ord k) => k -> [k] -> Bool
-t_partition _ ks = partCrit == partMap
-  where
-    fixup f (a,b) = (f a, f b)
-    partCrit = fixup CS.toList . CS.partition foo . CS.fromList $ ks
-    partMap  = fixup Set.toList . Set.partition foo . Set.fromList $ ks
-    foo = odd . byteCount
-
-propertiesFor :: (Arbitrary k, CritBitKey k, Ord k, Monoid k, Show k,
-                  IsString k) => k -> [Test]
-propertiesFor t = [
-    testProperty "t_fromList_toList" $ t_fromList_toList t
-  , testProperty "t_fromList_size" $ t_fromList_size t
-  , testProperty "t_null" $ t_null t
-  , testProperty "t_member_present" $ t_member_present t
-  , testProperty "t_member_missing" $ t_member_missing t
-#if MIN_VERSION_containers(0,5,0)
-  , testProperty "t_lookupGT" $ t_lookupGT t
-  , testProperty "t_lookupGE" $ t_lookupGE t
-  , testProperty "t_lookupLT" $ t_lookupLT t
-  , testProperty "t_lookupLE" $ t_lookupLE t
-#endif
-  , testProperty "t_delete_present" $ t_delete_present t
-  , testProperty "t_unions" $ t_unions t
-  , testProperty "t_difference" $ t_difference t
-  , testProperty "t_intersection" $ t_intersection t
-  , testProperty "t_foldl" $ t_foldl t
-  , testProperty "t_foldl'" $ t_foldl' t
-  , testProperty "t_elems" $ t_elems t
-  , testProperty "t_map" $ t_map t
-  , testProperty "t_mapKeys" $ t_map t
-  , testProperty "t_toAscList" $ t_toAscList t
-#if MIN_VERSION_containers(0,5,0)
-  , testProperty "t_toDescList" $ t_toDescList t
-#endif
-  , testProperty "t_fromAscList" $ t_fromAscList t
-  , testProperty "t_fromDistinctAscList" $ t_fromDistinctAscList t
-  , testProperty "t_filter" $ t_filter t
-  , testProperty "t_split_present" $ t_split_present t
-  , testProperty "t_split_missing" $ t_split_missing t
-  , testProperty "t_splitLookup_present" $ t_split_present t
-  , testProperty "t_splitLookup_missing" $ t_split_missing t
-  , testProperty "t_isProperSubsetOf_ambiguous" $
-      t_isProperSubsetOf_ambiguous t
-  , testProperty "t_findMin" $ t_findMin t
-  , testProperty "t_findMax" $ t_findMax t
-  , testProperty "t_deleteMin" $ t_deleteMin t
-  , testProperty "t_deleteMax" $ t_deleteMax t
-  , testProperty "t_deleteFindMin" $ t_deleteFindMin t
-  , testProperty "t_deleteFindMax" $ t_deleteFindMax t
-  , testProperty "t_minView" $ t_minView t
-  , testProperty "t_maxView" $ t_maxView t
-  , testProperty "t_insert_present" $ t_insert_present t
-  , testProperty "t_insert_missing" $ t_insert_missing t
-  , testProperty "t_foldMap" $ t_foldMap t
-  , testProperty "t_partition" $ t_partition t
+  , prop "t_fromAscList" $ (C.fromAscList =*== S.fromAscList) sort
+  , prop "t_fromDistinctAscList" $
+     (C.fromDistinctAscList =*== S.fromDistinctAscList) (nub . sort)
   ]
+  where
+    prop name q = [testProperty name $ q $ sameAs t]
+
+    sameAs :: (CritBitKey k, Ord k) => k -> SameAs (C.Set k) (S.Set k) [k]
+    sameAs _ = SameAs C.fromList C.toList S.fromList S.toList
 
 properties :: [Test]
 properties = [
@@ -282,10 +116,16 @@ properties = [
   , testGroup "bytestring" $ propertiesFor B.empty
   ]
 
+instance (Eq k) => Eq' (C.Set k) (S.Set k) where
+   c =^= m = C.toList c =^= S.toList m
+
+instance (Eq' a1 b1, Eq k) => Eq' (a1, C.Set k) (b1, S.Set k) where
+  (a1, a2) =^= (b1, b2) = a1 =^= b1 && a2 =^= b2
+
 -- Handy functions for fiddling with from ghci.
 
-blist :: [ByteString] -> CS.Set ByteString
-blist = CS.fromList
+blist :: [B.ByteString] -> C.Set B.ByteString
+blist = C.fromList
 
-tlist :: [Text] -> CS.Set Text
-tlist = CS.fromList
+tlist :: [T.Text] -> S.Set T.Text
+tlist = S.fromList

--- a/tests/Properties/Set.hs
+++ b/tests/Properties/Set.hs
@@ -8,11 +8,12 @@ import Data.CritBit.Map.Lazy (CritBitKey, byteCount)
 import qualified Data.CritBit.Set as C
 import qualified Data.Set as S
 
-import Test.QuickCheck (Arbitrary(..))
+import Test.QuickCheck (Arbitrary)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Data.String (IsString, fromString)
 import Data.List (unfoldr, sort, nub)
+import Data.Monoid (Monoid)
 
 import qualified Data.Text as T
 import qualified Data.ByteString.Char8 as B
@@ -26,11 +27,7 @@ kf k = fromString $ show (byteCount k) ++ show k
 kii :: (CritBitKey k, Show k, IsString k) => k -> Int -> Int
 kii k v = byteCount k * 13 + v
 
-fmono :: (CritBitKey k, Show k, IsString k) => k -> k
-fmono k = fromString $ "test" ++ show k
-
-propertiesFor :: (Arbitrary k, CritBitKey k, Eq k, Ord k, Show k, IsString k)
-              => k -> [Test]
+propertiesFor :: (Arbitrary k, CritBitKey k, Eq k, Ord k, Show k, IsString k, Monoid k) => k -> [Test]
 propertiesFor t = concat [[]
   -- * Operators
   , prop "t_diff" $ (C.\\) =**= (S.\\)
@@ -70,7 +67,7 @@ propertiesFor t = concat [[]
 
   -- * Map
   , prop "t_map" $ C.map kf =*= S.map kf
-  , prop "t_mapMonotonic" $ C.mapMonotonic fmono =*= S.mapMonotonic fmono
+  , prop "t_mapMonotonic" $ C.mapMonotonic prepends =*= S.mapMonotonic prepends
 
   -- * Folds
   , prop "t_foldr" $ C.foldr kii 0 =*= S.foldr kii 0


### PR DESCRIPTION
- Added tests for `Set`
- Refactored tests for `Map`
  - Revived not running tests
  - Fixed tests that used value of the type-providing (empty) key 
  - Unified tests

This pull request is independent, but is ready to be applied atop #69.

Tests for `split` and `splitLookup` fails, because current implementation of them is invalid. Fixed implementations come in #69.
