### PR TITLE
Benchmarks cleanup.

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -214,13 +214,13 @@ main = do
       , bgroup "delete" $ keyed C.delete Map.delete H.delete Trie.delete
       , bgroup "insert" $ keyed (flip C.insert 1) (flip Map.insert 1)
                                 (flip H.insert 1) (flip Trie.insert 1)
-      , bgroup "insertWith" $ [
-          bgroup "present" $ [
+      , bgroup "insertWith" [
+          bgroup "present" [
             bench "critbit" $ whnf (C.insertWith (+) key 1) b_critbit
           , bench "map" $ whnf (Map.insertWith (+) key 1) b_map
           , bench "hashmap" $ whnf (H.insertWith (+) key 1) b_hashmap
           ]
-        , bgroup "missing" $ [
+        , bgroup "missing" [
             bench "critbit" $ whnf (C.insertWith (+) key 1) b_critbit_1
           , bench "map" $ whnf (Map.insertWith (+) key 1) b_map_1
           , bench "hashmap" $ whnf (H.insertWith (+) key 1) b_hashmap_1
@@ -359,7 +359,7 @@ main = do
         ]
       , bgroup "map"  $ let f = (+3)
                         in function nf (C.map f) (Map.map f) (H.map f) (fmap f)
-      , bgroup "mapWithKey" $ [
+      , bgroup "mapWithKey" [
           bench "critbit" $ whnf (C.mapWithKey mapFKey) b_critbit
         , bench "map" $ whnf (Map.mapWithKey mapFKey) b_map
         ]
@@ -375,11 +375,11 @@ main = do
           bench "critbit" $ nf (C.mapKeysMonotonic f) b_critbit
         , bench "map" $ nf (Map.mapKeysMonotonic f) b_map
         ]
-      , bgroup "mapAccumWithKey" $ [
+      , bgroup "mapAccumWithKey" [
           bench "critbit" $ whnf (C.mapAccumWithKey mapAccumFKey 0) b_critbit
         , bench "map" $ whnf (Map.mapAccumWithKey mapAccumFKey 0) b_map
         ]
-      , bgroup "mapAccumRWithKey" $ [
+      , bgroup "mapAccumRWithKey" [
           bench "critbit" $ whnf (C.mapAccumRWithKey mapAccumFKey 0) b_critbit
         , bench "map" $ whnf (Map.mapAccumRWithKey mapAccumFKey 0) b_map
         ]
@@ -446,12 +446,12 @@ main = do
         , bench "map"     $ nf (Map.fromAscListWithKey (const (+))) b_ordKVs
         ]
       , bgroup "fromAscDistinctList_short" [
-          bench "critbit" $ nf (  C.fromDistinctAscList) b_ordKVs
-        , bench "map"     $ nf (Map.fromDistinctAscList) b_ordKVs
+          bench "critbit" $ nf   C.fromDistinctAscList b_ordKVs
+        , bench "map"     $ nf Map.fromDistinctAscList b_ordKVs
         ]
       , bgroup "fromAscDistinctList_long" [
-          bench "critbit" $ nf (  C.fromDistinctAscList) b_longKVs
-        , bench "map"     $ nf (Map.fromDistinctAscList) b_longKVs
+          bench "critbit" $ nf    C.fromDistinctAscList b_longKVs
+        , bench "map"     $ nf  Map.fromDistinctAscList b_longKVs
         ]
       , bgroup "filter" $ let p  = (< 128)
                               p' = \e -> if p e then Just e else Nothing
@@ -485,7 +485,7 @@ main = do
           bench "critbit" $ nf (C.mapEitherWithKey f) b_critbit
         , bench "map" $ nf (Map.mapEitherWithKey f) b_map
         ]
-      , bgroup "split" $ [
+      , bgroup "split" [
           bench "critbit" $ whnf (forcePair . C.split key) b_critbit
         , bench "map" $ whnf (forcePair . Map.split key) b_map
         ]
@@ -495,69 +495,69 @@ main = do
           bench "critbit" $ whnf (forceTriple . C.splitLookup key) b_critbit
         , bench "map" $ whnf (forceTriple . Map.splitLookup key) b_map
         ]
-      , bgroup "isSubmapOf" $ [
+      , bgroup "isSubmapOf" [
           bench "critbit" $ whnf (C.isSubmapOf b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOf b_map_1) b_map
         ]
-      , bgroup "isSubmapOfBy" $ [
+      , bgroup "isSubmapOfBy" [
           bench "critbit" $ whnf (C.isSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isSubmapOfBy (<=) b_map_1) b_map
         ]
-      , bgroup "isProperSubmapOf" $ [
+      , bgroup "isProperSubmapOf" [
           bench "critbit" $ whnf (C.isProperSubmapOf b_critbit_1) b_critbit
         , bench "map" $ whnf (Map.isProperSubmapOf b_map_1) b_map
         ]
-      , bgroup "isProperSubmapOfBy" $ [
+      , bgroup "isProperSubmapOfBy" [
           bench "critbit" $
             whnf (C.isProperSubmapOfBy (<=) b_critbit_1) b_critbit
         , bench "map" $
             whnf (Map.isProperSubmapOfBy (<=) b_map_1) b_map
         ]
-      , bgroup "findMin" $ [
-          bench "critbit" $ whnf (C.findMin) b_critbit
-        , bench "map" $ whnf (Map.findMin) b_map
+      , bgroup "findMin" [
+          bench "critbit" $ whnf C.findMin b_critbit
+        , bench "map" $ whnf Map.findMin b_map
         ]
-      , bgroup "findMax" $ [
-          bench "critbit" $ whnf (C.findMax) b_critbit
-        , bench "map" $ whnf (Map.findMax) b_map
+      , bgroup "findMax" [
+          bench "critbit" $ whnf C.findMax b_critbit
+        , bench "map" $ whnf Map.findMax b_map
         ]
-      , bgroup "deleteMin" $ [
-          bench "critbit" $ whnf (C.deleteMin) b_critbit
-        , bench "map" $ whnf (Map.deleteMin) b_map
+      , bgroup "deleteMin" [
+          bench "critbit" $ whnf C.deleteMin b_critbit
+        , bench "map" $ whnf Map.deleteMin b_map
         ]
-      , bgroup "deleteMax" $ [
-          bench "critbit" $ whnf (C.deleteMax) b_critbit
-        , bench "map" $ whnf (Map.deleteMax) b_map
+      , bgroup "deleteMax" [
+          bench "critbit" $ whnf C.deleteMax b_critbit
+        , bench "map" $ whnf Map.deleteMax b_map
        ]
-      , bgroup "deleteFindMin" $ [
+      , bgroup "deleteFindMin" [
           bench "critbit" $ whnf (snd . C.deleteFindMin) b_critbit
         , bench "map" $ whnf (snd . Map.deleteFindMin) b_map
         ]
-      , bgroup "deleteFindMax" $ [
+      , bgroup "deleteFindMax" [
           bench "critbit" $ whnf (snd . C.deleteFindMax) b_critbit
         , bench "map" $ whnf (snd . Map.deleteFindMax) b_map
         ]
-      , bgroup "minView" $ [
+      , bgroup "minView" [
           bench "critbit" $ whnf (snd . fromJust . C.minView) b_critbit
         , bench "map" $ whnf (snd . fromJust . Map.minView) b_map
         ]
-      , bgroup "maxView" $ [
+      , bgroup "maxView" [
           bench "critbit" $ whnf (snd . fromJust . C.maxView) b_critbit
         , bench "map" $ whnf (snd . fromJust . Map.maxView) b_map
         ]
-      , bgroup "minViewWithKey" $ [
+      , bgroup "minViewWithKey" [
           bench "critbit" $ whnf (snd . fromJust . C.minViewWithKey) b_critbit
         , bench "map" $ whnf (snd . fromJust . Map.minViewWithKey) b_map
         ]
-      , bgroup "maxViewWithKey" $ [
+      , bgroup "maxViewWithKey" [
           bench "critbit" $ whnf (snd . fromJust . C.minViewWithKey) b_critbit
         , bench "map" $ whnf (snd . fromJust . Map.minViewWithKey) b_map
         ]
-      , bgroup "updateMin" $ [
+      , bgroup "updateMin" [
           bench "critbit" $ whnf (C.updateMin updateFVal) b_critbit
         , bench "map" $ whnf (Map.updateMin updateFVal) b_map
         ]
-      , bgroup "updateMax" $ [
+      , bgroup "updateMax" [
           bench "critbit" $ whnf (C.updateMax updateFVal) b_critbit
         , bench "map" $ whnf (Map.updateMax updateFVal) b_map
         ]
@@ -569,15 +569,15 @@ main = do
         , bench "hashmap" $ nf (runIdentity . H.traverseWithKey f) b_hashmap
         , bench "trie" $ nf (fmap f) b_trie
         ]
-      , bgroup "updateMinWithKey" $ [
+      , bgroup "updateMinWithKey" [
           bench "critbit" $ whnf (C.updateMinWithKey updateFKey) b_critbit
         , bench "map" $ whnf (Map.updateMinWithKey updateFKey) b_map
         ]
-      , bgroup "updateMaxWithKey" $ [
+      , bgroup "updateMaxWithKey" [
           bench "critbit" $ whnf (C.updateMaxWithKey updateFKey) b_critbit
         , bench "map" $ whnf (Map.updateMaxWithKey updateFKey) b_map
         ]
-      , bgroup "foldMap" $ [
+      , bgroup "foldMap" [
           bench "critbit" $ let c_foldmap :: (C.CritBitKey k, Num v)
                                           => C.CritBit k v
                                           -> Sum v
@@ -604,7 +604,7 @@ main = do
           bench "critbit" $ whnf (forcePair . C.partitionWithKey predicate) b_critbit
         , bench "map" $ whnf (forcePair . Map.partitionWithKey predicate) b_map
      ]
-     , bgroup "partition" $ [
+     , bgroup "partition" [
           bench "critbit" $ whnf (forcePair . C.partition odd) b_critbit
         , bench "map" $ whnf (forcePair . Map.partition odd) b_map
      ]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -366,11 +366,11 @@ main = do
           bench "critbit" $ whnf (C.mapWithKey mapFKey) b_critbit
         , bench "map" $ whnf (Map.mapWithKey mapFKey) b_map
         ]
-      , bgroup "mapKeys" $ let f k = B.pack (show k ++ "test") in [
+      , bgroup "mapKeys" $ let f = (`mappend` "test") in [
           bench "critbit" $ nf (C.mapKeys f) b_critbit
         , bench "map" $ nf (Map.mapKeys f) b_map
         ]
-	  , bgroup "mapKeysWith" $ let f k = B.pack (show k ++ "test") in [
+	    , bgroup "mapKeysWith" $ let f = (`mappend` "test") in [
           bench "critbit" $ nf (C.mapKeysWith (+) f) b_critbit
         , bench "map" $ nf (Map.mapKeysWith (+) f) b_map
         ]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -101,7 +101,7 @@ main = do
               return "/usr/share/dict/words"
   ordKeys <- L.sort <$> (every 5 . B.words) <$> B.readFile fileName
              `Exc.catch` \(err::IOError) -> do
-               when (isDoesNotExistError err) $ do
+               when (isDoesNotExistError err) $
                  hPutStrLn stderr
                     ("(point the 'WORDS' environment variable at a file " ++
                      "to use it for benchmark data)")
@@ -145,10 +145,10 @@ main = do
         , bench "hashmap" $ whnf H.fromList kvs
         ]
       fromListWith kvs = [
-          bench "critbit" $ whnf (C.fromListWith (\a b -> a+b)) kvs
-        , bench "map" $ whnf (Map.fromListWith (\a b -> a+b)) kvs
-        , bench "hashmap" $ whnf (H.fromListWith (\a b -> a+b)) kvs
-        , bench "trie" $ whnf (TC.fromListWith (\a b -> a+b)) kvs
+          bench "critbit" $ whnf (C.fromListWith (+)) kvs
+        , bench "map" $ whnf (Map.fromListWith (+)) kvs
+        , bench "hashmap" $ whnf (H.fromListWith (+)) kvs
+        , bench "trie" $ whnf (TC.fromListWith (+)) kvs
         ]
       fromListWithKey kvs = [
           bench "critbit" $ whnf (C.fromListWithKey (\k a b -> a + b)) kvs

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -52,6 +52,9 @@ instance (NFData a) => NFData (Trie.Trie a) where
 forcePair:: (a,b) -> ()
 forcePair (a,b) = a `seq` b `seq` ()
 
+addvs :: (Num v) => k -> v -> v -> v
+addvs _ v1 v2 = v1 + v2
+
 every k = go 0
   where
     go i (x:xs)
@@ -151,8 +154,8 @@ main = do
         , bench "trie" $ whnf (TC.fromListWith (+)) kvs
         ]
       fromListWithKey kvs = [
-          bench "critbit" $ whnf (C.fromListWithKey (\k a b -> a + b)) kvs
-        , bench "map" $ whnf (Map.fromListWithKey (\k a b -> a+b)) kvs
+          bench "critbit" $ whnf (C.fromListWithKey addvs) kvs
+        , bench "map" $ whnf (Map.fromListWithKey addvs) kvs
         -- , bench "hashmap" $ whnf (H.fromListWithKey (\a b -> a+b)) kvs
         -- , bench "trie" $ whnf (TC.fromListWithKey (\a b -> a+b)) kvs
         ]
@@ -226,28 +229,28 @@ main = do
           , bench "hashmap" $ whnf (H.insertWith (+) key 1) b_hashmap_1
           ]
         ]
-      , bgroup "insertWithKey" $ let f _ a b = a + b in [
+      , bgroup "insertWithKey" [
           bgroup "present" [
-            bench "critbit" $ whnf (C.insertWithKey f key 1) b_critbit
-          , bench "map" $ whnf (Map.insertWithKey f key 1) b_map
+            bench "critbit" $ whnf (C.insertWithKey addvs key 1) b_critbit
+          , bench "map" $ whnf (Map.insertWithKey addvs key 1) b_map
           ]
         , bgroup "missing" [
-            bench "critbit" $ whnf (C.insertWithKey f key 1) b_critbit_1
-          , bench "map" $ whnf (Map.insertWithKey f key 1) b_map_1
+            bench "critbit" $ whnf (C.insertWithKey addvs key 1) b_critbit_1
+          , bench "map" $ whnf (Map.insertWithKey addvs key 1) b_map_1
           ]
         ]
-      , bgroup "insertLookupWithKey" $ let f _ a b = a + b in [
+      , bgroup "insertLookupWithKey" [
           bgroup "present" [
             bench "critbit" $
-                whnf (forcePair . C.insertLookupWithKey f key 1) b_critbit
+                whnf (forcePair . C.insertLookupWithKey addvs key 1) b_critbit
           , bench "map" $
-                whnf (forcePair . Map.insertLookupWithKey f key 1) b_map
+                whnf (forcePair . Map.insertLookupWithKey addvs key 1) b_map
           ]
         , bgroup "missing" [
             bench "critbit" $
-                whnf (forcePair . C.insertLookupWithKey f key 1) b_critbit_1
+                whnf (forcePair . C.insertLookupWithKey addvs key 1) b_critbit_1
           , bench "map" $
-                whnf (forcePair . Map.insertLookupWithKey f key 1) b_map_1
+                whnf (forcePair . Map.insertLookupWithKey addvs key 1) b_map_1
           ]
         ]
       , bgroup "adjust" $
@@ -388,9 +391,9 @@ main = do
           bench "critbit" $ whnf (C.unionWith (+) b_critbit_13) b_critbit_23
         , bench "map" $ whnf (Map.unionWith (+) b_map_13) b_map_23
         ]
-      , bgroup "unionWithKey" $ let f _ a b = a + b in [
-          bench "critbit" $ whnf (C.unionWithKey f b_critbit_13) b_critbit_23
-        , bench "map" $ whnf (Map.unionWithKey f b_map_13) b_map_23
+      , bgroup "unionWithKey" [
+          bench "critbit" $ whnf (C.unionWithKey addvs b_critbit_13) b_critbit_23
+        , bench "map" $ whnf (Map.unionWithKey addvs b_map_13) b_map_23
         ]
       , bgroup "unions" [
           bench "critbit" $ whnf C.unions [b_critbit_13, b_critbit_23]
@@ -423,9 +426,11 @@ main = do
         , bench "map" $ whnf (Map.intersectionWith (+) b_map_13) b_map_23
         , bench "hashmap" $ whnf (H.intersectionWith (+) b_hashmap_13) b_hashmap_23
         ]
-      , bgroup "intersectionWithKey" $ let f _ a b = a + b in [
-          bench "critbit" $ whnf (C.intersectionWithKey f b_critbit_13) b_critbit_23
-        , bench "map" $ whnf (Map.intersectionWithKey f b_map_13) b_map_23
+      , bgroup "intersectionWithKey" [
+          bench "critbit" $
+              whnf (C.intersectionWithKey addvs b_critbit_13) b_critbit_23
+        , bench "map" $
+              whnf (Map.intersectionWithKey addvs b_map_13) b_map_23
         ]
       , bgroup "toAscList" $ function nf C.toAscList Map.toAscList id id
       , bgroup "toDescList" $ function nf C.toDescList Map.toDescList id id

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -212,8 +212,8 @@ main = do
         , bgroup "reversed" $ fromListWithKey b_revKVs
         ]
       , bgroup "delete" $ keyed C.delete Map.delete H.delete Trie.delete
-      , bgroup "insert" $ keyed (flip C.insert 1) (flip Map.insert 1)
-                                (flip H.insert 1) (flip Trie.insert 1)
+      , bgroup "insert" $ keyed (`C.insert` 1) (`Map.insert` 1)
+                                (`H.insert` 1) (`Trie.insert` 1)
       , bgroup "insertWith" [
           bgroup "present" [
             bench "critbit" $ whnf (C.insertWith (+) key 1) b_critbit

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -603,9 +603,7 @@ main = do
           bench "critbit" $  whnf (C.alter altF key) b_critbit
         , bench "map" $ whnf (Map.alter altF key) b_map
         ]
-     , bgroup "partitionWithKey" $ let predicate k _ = odd $ C.byteCount k
-                                       forcePair (a,b) = a `seq` b `seq` (a,b)
-                                   in [
+     , bgroup "partitionWithKey" $ let predicate k _ = odd $ C.byteCount k in [
           bench "critbit" $ whnf (forcePair . C.partitionWithKey predicate) b_critbit
         , bench "map" $ whnf (forcePair . Map.partitionWithKey predicate) b_map
      ]


### PR DESCRIPTION
I am a little curious as to why there was no shadowing warning regarding `forcePair`, they had different return types but the same name.
