### PR TITLE
Solve compilation error in benchmarks due to Map.fromSet.

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -26,6 +26,7 @@ import qualified Data.CritBit.Map.Lazy as C
 import qualified Data.CritBit.Set as CSet
 import qualified Data.HashMap.Lazy as H
 import qualified Data.Map as Map
+import qualified Data.Map.Lazy as LMap
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Trie as Trie
@@ -358,7 +359,7 @@ main = do
           f = length . show
         in [
           bench "critbit" $ nf (C.fromSet f) (CSet.fromList keys)
-        , bench "map" $ nf (Map.fromSet f) (Set.fromList keys)
+        , bench "map" $ nf (LMap.fromSet f) (Set.fromList keys)
         ]
       , bgroup "map"  $ let f = (+3)
                         in function nf (C.map f) (Map.map f) (H.map f) (fmap f)

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -71,7 +71,7 @@ test-suite tests
   build-depends:
     base >= 4 && < 5,
     bytestring,
-    containers,
+    containers >= 0.5,
     critbit,
     QuickCheck >= 2.4,
     test-framework >= 0.4,
@@ -90,7 +90,7 @@ benchmark benchmarks
     base >= 4 && < 5,
     bytestring,
     bytestring-trie,
-    containers,
+    containers >= 0.5,
     critbit,
     criterion >= 0.8,
     deepseq,


### PR DESCRIPTION
The benchmarks suite fails to compile with

```
benchmarks/Benchmarks.hs:361:29:
    Not in scope: `Map.fromSet'
    Perhaps you meant one of these:
      `Map.fromList' (imported from Data.Map),
      `C.fromSet' (imported from Data.CritBit.Map.Lazy)
```

This is because function `fromSet` is in `Data.Map.Lazy`, not in `Data.Map`.
This patch adds the needed `import` line and modifies the `critbit.cabal` file
to place a lower-bound on `containers` package (`Data.Map.Lazy` exists since
`containers-0.5.0.0`.
