### PR TITLE
Fixed 'Module' comment in Core.hs

### DIFF
--- a/Data/CritBit/Core.hs
+++ b/Data/CritBit/Core.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns, RecordWildCards, ScopedTypeVariables #-}
 -- |
--- Module      :  Data.CritBit.Tree
+-- Module      :  Data.CritBit.Core
 -- Copyright   :  (c) Bryan O'Sullivan 2013
 -- License     :  BSD-style
 -- Maintainer  :  bos@serpentine.com


### PR DESCRIPTION
This file defines the Data.CritBit.Core module, don't let the comment claim otherwise!
