### PR TITLE
Add Semigroup intances for CritBit and Set

### DIFF
--- a/Data/CritBit/Set.hs
+++ b/Data/CritBit/Set.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -90,12 +91,20 @@ import Data.CritBit.Types.Internal (CritBit(..), Set(..), CritBitKey, Node(..))
 import Data.Foldable (Foldable, foldMap)
 import Data.Maybe (isJust)
 import Data.Monoid (Monoid(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup(..))
+#endif
 import Prelude hiding (null, filter, map, foldl, foldr)
 import qualified Data.CritBit.Tree as T
 import qualified Data.List as List
 
 instance (Show a) => Show (Set a) where
     show s = "fromList " ++ show (toList s)
+
+#if MIN_VERSION_base(4,9,0)
+instance CritBitKey k => Semigroup (Set k) where
+    (<>) = union
+#endif
 
 instance CritBitKey k => Monoid (Set k) where
     mempty  = empty

--- a/Data/CritBit/Set.hs
+++ b/Data/CritBit/Set.hs
@@ -108,7 +108,9 @@ instance CritBitKey k => Semigroup (Set k) where
 
 instance CritBitKey k => Monoid (Set k) where
     mempty  = empty
+#if !(MIN_VERSION_base(4,11,0))
     mappend = union
+#endif
     mconcat = unions
 
 instance Foldable Set where

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, RecordWildCards, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, BangPatterns, RecordWildCards, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -153,21 +153,31 @@ import Data.CritBit.Core
 import Data.CritBit.Types.Internal
 import Data.Maybe (fromMaybe)
 import Data.Monoid (Monoid(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.Traversable (Traversable(traverse))
 import Prelude hiding (foldl, foldr, lookup, null, map, filter)
 import qualified Data.Array as A
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
 
+#if MIN_VERSION_base(4,9,0)
+instance CritBitKey k => Semigroup (CritBit k v) where
+    (<>) = union
+#endif
+
 instance CritBitKey k => Monoid (CritBit k v) where
     mempty  = empty
+#if !(MIN_VERSION_base(4,11,0))
     mappend = union
+#endif
     mconcat = unions
 
 instance CritBitKey k => Traversable (CritBit k) where
     traverse f m = traverseWithKey (\_ v -> f v) m
 
-infixl 9 !, \\
+infixl 9 !, \\ -- Comment needed here to avoid CPP bug
 
 -- | /O(k)/. Find the value at a key.
 -- Calls 'error' when the element can not be found.
@@ -1247,8 +1257,7 @@ deleteMax m = updateMaxWithKey (\_ _ -> Nothing) m
 -- > deleteFindMin     Error: can not return the minimal element of an empty map
 deleteFindMin :: CritBit k v -> ((k, v), CritBit k v)
 deleteFindMin = fromMaybe (error msg) . minViewWithKey
-  where msg = "CritBit.deleteFindMin: cannot return the minimal \
-              \element of an empty map"
+  where msg = "CritBit.deleteFindMin: cannot return the minimal element of an empty map"
 {-# INLINABLE deleteFindMin #-}
 
 -- | /O(k)/. Delete and find the maximal element.
@@ -1257,8 +1266,7 @@ deleteFindMin = fromMaybe (error msg) . minViewWithKey
 -- > deleteFindMax     Error: can not return the maximal element of an empty map
 deleteFindMax :: CritBit k v -> ((k, v), CritBit k v)
 deleteFindMax = fromMaybe (error msg) . maxViewWithKey
-  where msg = "CritBit.deleteFindMax: cannot return the minimal \
-              \element of an empty map"
+  where msg = "CritBit.deleteFindMax: cannot return the minimal element of an empty map"
 {-# INLINABLE deleteFindMax #-}
 
 -- | /O(k')/. Retrieves the value associated with minimal key of the

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -96,7 +96,7 @@ benchmark benchmarks
     critbit,
     criterion >= 0.8,
     deepseq,
-    hashable < 1.2,
+    hashable < 1.3,
     mtl,
     mwc-random,
     text,


### PR DESCRIPTION
Currently, `critbit` fails to build on GHC 8.4 since `Semigroup` has become a superclass of `Monoid`, and the `CritBit` and `Set` data types lack `Semigroup` instances.

I opted to use CPP to define a `Semigroup` instance on `base-4.9` or later only. If you'd like, I could alternatively incur a `semigroups` dependency to remove this bit of CPP.