### PR TITLE
Update to current GHC, dependency updates, stack.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cabal-dev
 .cabal-sandbox
 cabal.sandbox.config
 dist
+.stack-work

--- a/Data/CritBit/Set.hs
+++ b/Data/CritBit/Set.hs
@@ -97,9 +97,11 @@ import qualified Data.List as List
 instance (Show a) => Show (Set a) where
     show s = "fromList " ++ show (toList s)
 
+instance CritBitKey k => Semigroup (Set k) where
+    (<>) = union
+
 instance CritBitKey k => Monoid (Set k) where
     mempty  = empty
-    mappend = union
     mconcat = unions
 
 instance Foldable Set where

--- a/Data/CritBit/Tree.hs
+++ b/Data/CritBit/Tree.hs
@@ -159,9 +159,11 @@ import qualified Data.Array as A
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
 
+instance CritBitKey k => Semigroup (CritBit k v) where
+    (<>) = union
+
 instance CritBitKey k => Monoid (CritBit k v) where
     mempty  = empty
-    mappend = union
     mconcat = unions
 
 instance CritBitKey k => Traversable (CritBit k) where

--- a/Data/CritBit/Types/Internal.hs
+++ b/Data/CritBit/Types/Internal.hs
@@ -28,7 +28,6 @@ module Data.CritBit.Types.Internal
 import Control.DeepSeq (NFData(..))
 import Data.Bits (Bits, (.|.), (.&.), shiftL, shiftR)
 import Data.ByteString (ByteString)
-import Data.Foldable hiding (toList)
 import Data.Monoid (Monoid(..))
 import Data.Text ()
 import Data.Text.Internal (Text(..))

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -371,7 +371,7 @@ main = do
           bench "critbit" $ nf (C.mapKeys f) b_critbit
         , bench "map" $ nf (Map.mapKeys f) b_map
         ]
-	    , bgroup "mapKeysWith" $ let f = (`mappend` "test") in [
+      , bgroup "mapKeysWith" $ let f = (`mappend` "test") in [
           bench "critbit" $ nf (C.mapKeysWith (+) f) b_critbit
         , bench "map" $ nf (Map.mapKeysWith (+) f) b_map
         ]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -7,7 +7,7 @@ import Control.DeepSeq (NFData(..))
 import Control.Monad (when)
 import Control.Monad.Trans (liftIO)
 import Criterion.Main (bench, bgroup, defaultMain, nf, whnf)
-import Criterion.Types (Pure)
+import Criterion.Types (Benchmarkable)
 import Data.Foldable (foldMap)
 import Data.Functor.Identity (Identity(..))
 import Data.Hashable (Hashable(..), hashByteArray)
@@ -180,7 +180,7 @@ main = do
         , bench "hashmap" $ whnf (hashmap b_hashmap_13) b_hashmap_23
         , bench "trie" $ whnf (trie b_trie_13) b_trie_23
         ]
-      function (eval :: forall a b. NFData b => (a -> b) -> a -> Pure)
+      function (eval :: forall a b. NFData b => (a -> b) -> a -> Benchmarkable)
                critbit map hashmap trie = [
          bench "critbit" $ eval critbit b_critbit
        , bench "map" $ eval map b_map

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -89,14 +89,14 @@ benchmark benchmarks
   ghc-options:    -O2 -rtsopts
 
   build-depends:
-    base >= 4 && < 5,
+    base >= 4.11 && < 5,
     bytestring,
     bytestring-trie,
     containers,
     critbit,
     criterion >= 0.8,
     deepseq,
-    hashable < 1.2,
+    hashable >= 1.2 && < 1.3,
     mtl,
     mwc-random,
     text,

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -43,7 +43,7 @@ library
 
   build-depends:
     array,
-    base >= 4 && < 5,
+    base >= 4.11 && < 5,
     bytestring >= 0.9,
     deepseq,
     text >= 0.11.2.3,
@@ -71,7 +71,7 @@ test-suite tests
 
   build-depends:
     QuickCheck >= 2.7,
-    base >= 4 && < 5,
+    base >= 4.11 && < 5,
     bytestring,
     containers,
     critbit,

--- a/critbit.cabal
+++ b/critbit.cabal
@@ -1,5 +1,5 @@
 name:           critbit
-version:        0.2.0.0
+version:        0.2.1.0
 homepage:       https://github.com/bos/critbit
 bug-reports:    https://github.com/bos/critbit/issues
 synopsis:       Crit-bit maps and sets

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-13.21
+
+packages:
+- .
+
+extra-deps:
+- bytestring-trie-0.2.5.0


### PR DESCRIPTION
Some assorted changes to get `critbit` to build with current GHC.

- update for Semigroup/Monoid typeclass change
- update for criterion `Pure` -> `Benchmark` type change
- selective cabal dependency updates (mostly against `base`, also `hashable`)
- include a `stack.yaml` that works for me
- bump cabal version number to 0.2.1.0

I'm happy to adapt any of these changes, or split them up -- whatever seems right to you.

One note is that I get some test failures (on macos). I have not managed to run the tests with the previous version, so I'm not sure whether they were introduced by some of the dependency updates.
