### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/critbit.cabal
+++ b/critbit.cabal
@@ -23,7 +23,7 @@ maintainer:     Bryan O'Sullivan <bos@serpentine.com>
 copyright:      2013-2014 Bryan O'Sullivan and others
 category:       Data
 build-type:     Simple
-cabal-version:  >= 1.14
+cabal-version:  1.14
 extra-source-files:
     README.markdown
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: critbit.cabal:26:24: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.14'.
```